### PR TITLE
sync: add Barrier feature.

### DIFF
--- a/sync/presets.go
+++ b/sync/presets.go
@@ -10,6 +10,8 @@ import (
 	capi "github.com/hashicorp/consul/api"
 )
 
+// PeerSubtree represents a subtree under the test run's sync tree where peers
+// participating in this distributed test advertise themselves.
 var PeerSubtree = &Subtree{
 	PayloadType: reflect.TypeOf(&peer.AddrInfo{}),
 	PathFunc: func(val interface{}) string {

--- a/sync/subtree.go
+++ b/sync/subtree.go
@@ -8,8 +8,9 @@ import (
 	"github.com/ipfs/testground/logging"
 )
 
-// A Subtree represents a subtree of the sync tree under a test, tied with
-// a particular path pattern, storing payloads of a specific type.
+// A Subtree represents a subtree of the sync tree for a test run. It is bound
+// to a particular subpath pattern, where payloads of a specific type are posted
+// and manipulated.
 type Subtree struct {
 	// PayloadType is the type of the payload. Must be a pointer type.
 	PayloadType reflect.Type


### PR DESCRIPTION
Introduces a Barrier synchronisation primitive, useful for distributed test scenarios where many nodes signal their entry into a condition, and peers need to wait until N nodes have entered that condition.