### PR TITLE
propagate test parameters from CLI to runenv.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -81,7 +81,7 @@ func parseBuildInput(c *cli.Context) (*build.Input, error) {
 		cfg  = c.StringSlice("build-cfg")
 	)
 
-	d, err := util.ToOptionsMap(deps)
+	d, err := util.ToOptionsMap(deps, false)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func parseBuildInput(c *cli.Context) (*build.Input, error) {
 		return nil, err
 	}
 
-	config, err := util.ToOptionsMap(cfg)
+	config, err := util.ToOptionsMap(cfg, true)
 	if err != nil {
 		return nil, err
 	}

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -30,6 +30,7 @@ instances = { min = 2, max = 100, default = 50 }
 
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
+  timeout_secs = { type = "int", desc = "timeout", unit = "seconds"}
 
 # seq 1
 [[testcases]]

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -241,7 +241,7 @@ func (*LocalDockerRunner) Run(input *Input) (*Output, error) {
 			reader := containerReader{
 				ReadCloser: rpipe,
 				id:         id,
-				color:      uint8(n % 16),
+				color:      uint8(n%15) + 1,
 			}
 
 			go func() {

--- a/pkg/util/options.go
+++ b/pkg/util/options.go
@@ -8,11 +8,11 @@ import (
 
 // ToOptionsMap converts a slice of ["KEY1=VAL1", "KEY2=VAL2", ...] dictionary
 // values into a map of interface{}, where the actual type is determined by
-// guessing.
+// guessing if guessTypes is true, or else it remains a string.
 //
 // TODO may need to be extended to support variadic values, returning a
 // map[string][]string (a map of string keys to string slices).
-func ToOptionsMap(input []string) (res map[string]interface{}, err error) {
+func ToOptionsMap(input []string, guessTypes bool) (res map[string]interface{}, err error) {
 	res = make(map[string]interface{}, len(input))
 	var v interface{}
 	for _, d := range input {
@@ -21,17 +21,18 @@ func ToOptionsMap(input []string) (res map[string]interface{}, err error) {
 			return nil, fmt.Errorf("invalid key-value: %s", d)
 		}
 
-		// 1. Try to parse as an integer.
-		// 2. Try to parse as a float.
-		// 3. Try to parse as a bool.
-		// 4. It is a string, try to unquote.
-		// 5. Use as string value.
-		if v, err = strconv.Atoi(splt[1]); err == nil {
-		} else if v, err = strconv.ParseFloat(splt[1], 64); err == nil {
-		} else if v, err = strconv.ParseBool(splt[1]); err == nil {
-		} else if v, err = strconv.Unquote(splt[1]); err == nil {
-		} else {
-			v = splt[1]
+		v = splt[1]
+		if guessTypes {
+			// 1. Try to parse as an integer.
+			// 2. Try to parse as a float.
+			// 3. Try to parse as a bool.
+			// 4. It is a string, try to unquote.
+			// 5. Default to string value.
+			if v, err = strconv.Atoi(splt[1]); err == nil {
+			} else if v, err = strconv.ParseFloat(splt[1], 64); err == nil {
+			} else if v, err = strconv.ParseBool(splt[1]); err == nil {
+			} else if v, err = strconv.Unquote(splt[1]); err == nil {
+			}
 		}
 		res[splt[0]] = v
 	}

--- a/plans/dht/lookup_peers.go
+++ b/plans/dht/lookup_peers.go
@@ -26,6 +26,20 @@ func LookupPeers(runenv *runtime.RunEnv) {
 		}
 	}()
 
+	// TODO Make parameter getting nicer by providing typed accessors in the
+	// RunEnv (à la urfave/cli), that accept a second argument (default value).
+	bucketSize := func() int {
+		if t, ok := runenv.IntParam("bucket_size"); !ok {
+			return 20
+		} else {
+			return t
+		}
+	}()
+
+	// moot assignment to pacify the compiler. We need to merge the configurable
+	// bucket size param upstream.
+	_ = bucketSize
+
 	h, err := libp2p.New(context.Background())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Now we can provide parameters to test cases. There are three types of parameters/options passable via LCI:

* builder configuration overrides, e.g. bypass the cache.
* runner configuration overrides, e.g. log level.
* test parameters: settings that are specific to the test behaviour, e.g. bucket size, timeout values, etc.