### PR TITLE
Plan: dht

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ Ensure that you are running go 1.13 or later (for gomod support)
 go version go1.13.1 darwin/amd64
 ```
 
-You will need docker and the redis docker image. Learn how to install docker on your machine at https://docs.docker.com/install and once you have completed, pull the redis image with:
-
-```
-docker pull redis
-```
-
 Then, onto getting the actual Test Ground code. Download the repo and install the dependencies
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ Ensure that you are running go 1.13 or later (for gomod support)
 go version go1.13.1 darwin/amd64
 ```
 
-Download the repo and install the dependencies
+You will need docker and the redis docker image. Learn how to install docker on your machine at https://docs.docker.com/install and once you have completed, pull the redis image with:
+
+```
+docker pull redis
+```
+
+Then, onto getting the actual Test Ground code. Download the repo and install the dependencies
 
 ```sh
 > go get git@github.com:ipfs/testground.git
@@ -96,21 +102,7 @@ NAME:
 
 ### Running the tests locally with TestGround
 
-To run a test locally, you can use the `testground run` command. Check what Test Plans are available in the `plans` folder
-
-```
-> ls plans
-dht      smlbench
-```
-
-Then do
-
-```
-> TESTGROUND_BASEDIR=`pwd` testground run dht/lookup-peers --builder=docker:go --runner=local:docker
-..
-```
-
-To check which Test Plan and Test Cases are available do:
+To run a test locally, you can use the `testground run` command. Check what Plans and Tests are available by running the `list` command:
 
 ```
 > TESTGROUND_BASEDIR=`pwd` testground list
@@ -122,6 +114,15 @@ smlbench/lookup-peers
 smlbench/lookup-providers
 smlbench/store-get-value
 ```
+
+Then do
+
+```
+> TESTGROUND_BASEDIR=`pwd` testground -vv run dht/lookup-peers --builder=docker:go --runner=local:docker --build-cfg bypass_cache=true
+...
+```
+
+To check which Test Plan and Test Cases are available do:
 
 ### Running a test outside of TestGround orchestrator
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ dht      smlbench
 Then do
 
 ```
-> TESTGROUND_BASEDIR=`pwd` testground run dht/lookup-peers --builder=docker:go
+> TESTGROUND_BASEDIR=`pwd` testground run dht/lookup-peers --builder=docker:go --runner=local:docker
 ..
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ NAME:
      --help, -h  show help
 ```
 
-### Running the tests locally
+### Running the tests locally with TestGround
 
 To run a test locally, you can use the `testground run` command. Check what Test Plans are available in the `plans` folder
 
@@ -123,7 +123,27 @@ smlbench/lookup-providers
 smlbench/store-get-value
 ```
 
-### Running a Test Plan on the TestGround infrastructure
+### Running a test outside of TestGround orchestrator
+
+You must have a redis instance running locally. Install it for your runtime follow instruction at https://redis.io/download.
+
+Then run it locally with
+
+```
+> redis server
+# ...
+93801:M 03 Oct 2019 14:42:52.430 * Ready to accept connections
+```
+
+Then move into the folder that has the plan and test you want to run locally. Execute it by sessting the TEST_CASE & TEST_CASE_SEQ env variables
+
+```
+> cd plans/dht
+> TEST_CASE="lookup-peers" TEST_CASE_SEQ="0" go run main.go
+# ... test output
+```
+
+### Running a Test Plan on the TestGround Cloud Infrastructure
 
 `To be Written once such infrastructure exists..soon™`
 

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -8,18 +8,21 @@ enabled = true
 go_version = "1.13"
 module_path = "github.com/ipfs/testground/plans/dht"
 exec_pkg = "."
-  
+
+# TODO: exec:go is not ready yet
 [build_strategies."exec:go"]
 enabled = true
 module_path = "github.com/ipfs/testground/plans/dht"
 exec_pkg = "."
 
-[run_strategies."local:exec"]
-enabled = true
-
 [run_strategies."local:docker"]
 enabled = true
 
+# TODO: local:exec is not ready yet
+[run_strategies."local:exec"]
+enabled = true
+
+# TODO: local:exec is not ready yet
 [run_strategies."cluster:nomad"]
 enabled = true
 
@@ -48,4 +51,3 @@ roles = ["storer", "fetcher"]
 
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
-

--- a/plans/dht/main.go
+++ b/plans/dht/main.go
@@ -1,9 +1,14 @@
 package main
 
-import "github.com/ipfs/testground/sdk/runtime"
+import (
+  "github.com/ipfs/testground/sdk/runtime"
+  test "github.com/ipfs/testground/plans/dht/test"
+)
 
 var testCases = []func(*runtime.RunEnv){
-	LookupPeers,
+	test.LookupPeers,
+	test.LookupProviders,
+	test.StoreGetValue,
 }
 
 func main() {

--- a/plans/dht/test/lookup_peers.go
+++ b/plans/dht/test/lookup_peers.go
@@ -1,4 +1,4 @@
-package main
+package test
 
 import (
 	"context"

--- a/plans/dht/test/lookup_providers.go
+++ b/plans/dht/test/lookup_providers.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+func LookupProviders(runenv *runtime.RunEnv) {
+	fmt.Printf("Not implemented yet")
+
+	runenv.OK()
+}

--- a/plans/dht/test/store_get_value.go
+++ b/plans/dht/test/store_get_value.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+func StoreGetValue(runenv *runtime.RunEnv) {
+	fmt.Printf("Not Implemented Yet")
+
+	runenv.OK()
+}


### PR DESCRIPTION
Apologies if this looks like coming out of nowhere but I'm trying to contribute to both existing Plans as I do #58 to master the whole codebase.

**Update:** Got working on my machine correctly https://github.com/ipfs/testground/pull/59#issuecomment-538274470

------------

I got blocked on an error that I haven't had seen before but I suspect it is gomod/goproxy/gosomething related. When running:

```
> TESTGROUND_BASEDIR=`pwd` testground run dht/lookup-peers --builder=docker:go
```

I got

```
 ---> Running in 6cd8ea6da2be
go: github.com/btcsuite/btcd@v0.0.0-20190926002857-ba530c4abb35 requires
        github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495: invalid version: git -c protocol.version=0 fetch --unshallow -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /go/pkg/mod/cache/vcs/d9a489aa71aa9542aea8f66dfdd8c20fc0c90a8f7154b9b36206e404c9b1551e: exit status 128:
        fatal: unable to access 'https://github.com/davecgh/go-spew/': gnutls_handshake() failed: The TLS connection was non-properly terminated.
```

and when trying to run again, I'm getting

```
> TESTGROUND_BASEDIR=`pwd` testground run dht/lookup-peers --builder=docker:go

resolved testground base dir from env variable: /Users/imp/code/go-projects/src/github.com/ipfs/testground
found cached docker image for: testground-dht:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
unknown runner
```

Any tips of wisdom? 

