### PR TITLE
WIP: cluster:swarm runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 testground
 
 plans/**/go.sum
+.env.toml
 
 # Created by https://www.gitignore.io/api/go,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=go,visualstudiocode

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
+	github.com/aws/aws-sdk-go v1.15.78
 	github.com/containerd/containerd v1.2.9 // indirect
 	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 // indirect
 	github.com/davecgh/go-spew v1.1.1

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -18,12 +18,10 @@ exec_pkg = "."
 [run_strategies."local:docker"]
 enabled = true
 
-# TODO: local:exec is not ready yet
 [run_strategies."local:exec"]
 enabled = true
 
-# TODO: local:exec is not ready yet
-[run_strategies."cluster:nomad"]
+[run_strategies."cluster:swarm"]
 enabled = true
 
 # seq 0

--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -20,6 +20,11 @@ type Builder interface {
 
 // BuildInput encapsulates the input options for building a test plan.
 type BuildInput struct {
+	// BuildID is a unique ID for this build.
+	BuildID string
+	// EnvConfig is the env configuration of the engine. Not a pointer to force
+	// a copy.
+	EnvConfig EnvConfig
 	// Directories providers accessors to directories managed by the runtime.
 	Directories Directories
 	// TestPlan is the metadata of the test plan being built.

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 )
 
+type ConfigMap map[string]interface{}
+
 // Directories providers accessors to directories managed by the testground
 // runtime (engine).
 type Directories interface {

--- a/pkg/api/definitions.go
+++ b/pkg/api/definitions.go
@@ -10,8 +10,6 @@ type TestPlanDefinition struct {
 	TestCases       []*TestCase          `toml:"testcases"`
 }
 
-type ConfigMap map[string]interface{}
-
 // TestCase represents a configuration for a test case known by the system.
 type TestCase struct {
 	Name      string

--- a/pkg/api/env.go
+++ b/pkg/api/env.go
@@ -1,0 +1,15 @@
+package api
+
+// EnvConfig represents an environment configuration read from an .env.toml
+// file.
+type EnvConfig struct {
+	AWS             AWSConfig            `toml:"aws"`
+	BuildStrategies map[string]ConfigMap `toml:"build_strategies"`
+	RunStrategies   map[string]ConfigMap `toml:"run_strategies"`
+}
+
+type AWSConfig struct {
+	AccessKeyID     string `toml:"access_key_id"`
+	SecretAccessKey string `toml:"secret_access_key"`
+	Region          string `toml:"region"`
+}

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ipfs/testground/pkg/api"
+	"github.com/ipfs/testground/pkg/aws"
 	"github.com/ipfs/testground/pkg/build"
 	"github.com/ipfs/testground/pkg/util"
 
@@ -39,18 +40,26 @@ type DockerGoBuilderConfig struct {
 	ExecPkg       string `toml:"exec_pkg" overridable:"yes"`
 	FreshGomod    bool   `toml:"fresh_gomod" overridable:"yes"`
 	BypassCache   bool   `toml:"bypass_cache" overridable:"yes"`
+
+	// PushRegistry, if true, will push the resulting image to a Docker
+	// registry.
+	PushRegistry bool `toml:"push_registry" overridable:"yes"`
+
+	// RegistryType is the type of registry this builder will push the generated
+	// Docker image to, if PushRegistry is true.
+	RegistryType string `toml:"registry_type" overridable:"yes"`
 }
 
 // TODO cache build outputs https://github.com/ipfs/testground/issues/36
 // Build builds a testplan written in Go and outputs a Docker container.
-func (b *DockerGoBuilder) Build(opts *api.BuildInput) (*api.BuildOutput, error) {
-	cfg, ok := opts.BuildConfig.(*DockerGoBuilderConfig)
+func (b *DockerGoBuilder) Build(in *api.BuildInput) (*api.BuildOutput, error) {
+	cfg, ok := in.BuildConfig.(*DockerGoBuilderConfig)
 	if !ok {
-		return nil, fmt.Errorf("expected configuration type DockerGoBuilderConfig, was: %T", opts.BuildConfig)
+		return nil, fmt.Errorf("expected configuration type DockerGoBuilderConfig, was: %T", in.BuildConfig)
 	}
 
 	var (
-		id          = build.CanonicalBuildID(opts)
+		id          = build.CanonicalBuildID(in)
 		cli, err    = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
 	)
@@ -71,17 +80,17 @@ func (b *DockerGoBuilder) Build(opts *api.BuildInput) (*api.BuildOutput, error) 
 	}
 
 	// Create a temp dir, and copy the source into it.
-	tmp, err := ioutil.TempDir("", opts.TestPlan.Name)
+	tmp, err := ioutil.TempDir("", in.TestPlan.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed while creating temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmp)
 
 	var (
-		plansrc        = opts.TestPlan.SourcePath
-		sdksrc         = filepath.Join(opts.Directories.SourceDir(), "/sdk")
-		dockerfilesrc  = filepath.Join(opts.Directories.SourceDir(), "pkg/build/golang", "Dockerfile.template")
-		installipfssrc = filepath.Join(opts.Directories.SourceDir(), "pkg", "build", "install-ipfs.sh")
+		plansrc        = in.TestPlan.SourcePath
+		sdksrc         = filepath.Join(in.Directories.SourceDir(), "/sdk")
+		dockerfilesrc  = filepath.Join(in.Directories.SourceDir(), "pkg/build/golang", "Dockerfile.template")
+		installipfssrc = filepath.Join(in.Directories.SourceDir(), "pkg", "build", "install-ipfs.sh")
 
 		plandst        = filepath.Join(tmp, "plan")
 		sdkdst         = filepath.Join(tmp, "sdk")
@@ -140,7 +149,7 @@ func (b *DockerGoBuilder) Build(opts *api.BuildInput) (*api.BuildOutput, error) 
 
 	// If we have version overrides, apply them.
 	var replaces []string
-	for mod, ver := range opts.Dependencies {
+	for mod, ver := range in.Dependencies {
 		// TODO(RK): allow to override target of replaces, so we can test against forks.
 		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, mod, ver))
 	}
@@ -164,28 +173,77 @@ func (b *DockerGoBuilder) Build(opts *api.BuildInput) (*api.BuildOutput, error) 
 		return nil, err
 	}
 
-	args := map[string]*string{
-		"GO_VERSION":        &cfg.GoVersion,
-		"GO_IPFS_VERSION":   &cfg.GoIPFSVersion,
-		"TESTPLAN_EXEC_PKG": &cfg.ExecPkg,
+	opts := types.ImageBuildOptions{
+		Tags: []string{id, in.BuildID},
+		BuildArgs: map[string]*string{
+			"GO_VERSION":        &cfg.GoVersion,
+			"GO_IPFS_VERSION":   &cfg.GoIPFSVersion,
+			"TESTPLAN_EXEC_PKG": &cfg.ExecPkg,
+		},
 	}
 
-	buildOpts := types.ImageBuildOptions{
-		Tags:      []string{id},
-		BuildArgs: args,
-	}
-
-	resp, err := cli.ImageBuild(ctx, tar, buildOpts)
+	// Build the image.
+	resp, err := cli.ImageBuild(ctx, tar, opts)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
+	// Pipe the docker output to stdout.
 	if err := util.PipeDockerOutput(resp.Body, os.Stdout); err != nil {
 		return nil, err
 	}
 
-	return &api.BuildOutput{ArtifactPath: id}, nil
+	out := &api.BuildOutput{ArtifactPath: in.BuildID}
+
+	if cfg.PushRegistry {
+		err := b.pushToRegistry(ctx, cli, in, out)
+		return out, err
+	}
+
+	return out, nil
+}
+
+func (b *DockerGoBuilder) pushToRegistry(ctx context.Context, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
+	cfg := in.BuildConfig.(*DockerGoBuilderConfig)
+
+	switch cfg.RegistryType {
+	case "aws":
+		goto AWS
+	}
+
+AWS:
+	// Get a Docker registry authentication token from AWS ECR.
+	auth, err := aws.ECR.GetAuthToken(in.EnvConfig.AWS)
+	if err != nil {
+		return err
+	}
+
+	// AWS ECR repository name is testground-<plan_name>.
+	repo := fmt.Sprintf("testground-%s", in.TestPlan.Name)
+
+	// Ensure the repo exists, or create it. Get the full URI to the repo, so we
+	// can tag images.
+	uri, err := aws.ECR.EnsureRepository(in.EnvConfig.AWS, repo)
+
+	// Tag the image under the AWS ECR repository.
+	tag := uri + ":" + in.BuildID
+	if err = client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {
+		return err
+	}
+
+	rc, err := client.ImagePush(ctx, uri, types.ImagePushOptions{
+		RegistryAuth: aws.ECR.EncodeAuthToken(*auth),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Pipe the docker output to stdout.
+	if err := util.PipeDockerOutput(rc, os.Stdout); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateSdkDir(dir string) error {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -25,6 +25,7 @@ var AllBuilders = []api.Builder{
 var AllRunners = []api.Runner{
 	&runner.LocalDockerRunner{},
 	&runner.LocalExecutableRunner{},
+	&runner.ClusterSwarmRunner{},
 }
 
 // Engine is the central runtime object of the system. It knows about all test

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -91,6 +91,9 @@ func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
 		env = append(env, "LOG_LEVEL="+cfg.LogLevel)
 	}
 
+  // Temp Redis fix
+	env = append(env, "REDIS_HOST=172.31.14.166")
+
 	// Create a docker client.
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -112,12 +115,17 @@ func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
     },
     TaskTemplate: swarm.TaskSpec{
       ContainerSpec: &swarm.ContainerSpec{
-        Image: "alpine",
+        Image: "909427826938.dkr.ecr.us-west-2.amazonaws.com/testground:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855@sha256:e175f10c2fc0545ede1de08458dffbea5b3efb3c023963028eac9129f4fd5920",
         Env: env,
-        Command: []string{ "ping", "docker.com" },
       },
-      // RestartPolicy
-      // Networks
+      RestartPolicy: &swarm.RestartPolicy{
+        Condition: swarm.RestartPolicyConditionNone,
+      },
+      Networks: []swarm.NetworkAttachmentConfig{
+        {
+          Target: "hw6dcms11qhf3iv3rr2j8a2vb",
+        },
+      },
     },
     Mode: swarm.ServiceMode{
       Replicated: &swarm.ReplicatedService{

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -1,1 +1,154 @@
 package runner
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/util"
+	"github.com/ipfs/testground/sdk/runtime"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+
+	"github.com/imdario/mergo"
+)
+
+var (
+	_ Runner = &ClusterSwarmRunner{}
+)
+
+// ClusterSwarmRunnerConfig is the configuration object of this runner. Boolean
+// values are expressed in a way that zero value (false) is the default setting.
+type ClusterSwarmRunnerConfig struct {
+	// LogLevel sets the log level in the test containers (default: not set).
+	LogLevel string `toml:"log_level"`
+}
+
+// defaultClusterSwarmConfig is the default configuration. Incoming configurations will be
+// merged with this object.
+var defaultClusterSwarmConfig = ClusterSwarmRunnerConfig{
+}
+
+// ClusterSwarmRunner is a runner that creates a Docker service to launch as
+// many replicated instances of a container as the run job indicates.
+type ClusterSwarmRunner struct{}
+
+// TODO runner option to keep containers alive instead of deleting them after
+// the test has run.
+func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
+	var (
+		// image    = input.ArtifactPath
+		seq      = input.Seq
+		deferred []func() error
+		log      = logging.S().With("runner", "cluster:swarm", "run_id", input.ID)
+	)
+
+	defer func() {
+		for i := len(deferred) - 1; i >= 0; i-- {
+			if err := deferred[i](); err != nil {
+				log.Errorw("error while calling deferred functions", "error", err)
+			}
+		}
+	}()
+
+	var (
+		cfg   = defaultClusterSwarmConfig
+		incfg = input.RunnerConfig.(*ClusterSwarmRunnerConfig)
+	)
+
+	// Merge the incoming configuration with the default configuration.
+	if err := mergo.Merge(&cfg, incfg, mergo.WithOverride); err != nil {
+		return nil, fmt.Errorf("error while merging configurations: %w", err)
+	}
+
+	// Sanity check.
+	if seq < 0 || seq >= len(input.TestPlan.TestCases) {
+		return nil, fmt.Errorf("invalid test case seq %d for plan %s", seq, input.TestPlan.Name)
+	}
+
+	// Get the test case.
+	testcase := input.TestPlan.TestCases[seq]
+
+	// Build a runenv.
+	runenv := &runtime.RunEnv{
+		TestPlan:           input.TestPlan.Name,
+		TestCase:           testcase.Name,
+		TestRun:            input.ID,
+		TestCaseSeq:        seq,
+		TestInstanceCount:  input.Instances,
+		TestInstanceParams: input.Parameters,
+	}
+
+	// Serialize the runenv into env variables to pass to docker.
+	env := util.ToOptionsSlice(runenv.ToEnvVars())
+
+	// Set the log level if provided in cfg.
+	if cfg.LogLevel != "" {
+		env = append(env, "LOG_LEVEL="+cfg.LogLevel)
+	}
+
+	// Create a docker client.
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, err
+	}
+
+	// Start service
+	// name := fmt.Sprintf("tg-%s-%s-%s", input.TestPlan.Name, testcase.Name, input.ID)
+	name := fmt.Sprintf("tg-%s-%s", input.TestPlan.Name, testcase.Name)
+
+	log.Infow("creating service", "name", name)
+
+  // docker service create --replicas 1 --name helloworld alpine ping docker.com
+
+  replicas := uint64(input.Instances)
+  spec := swarm.ServiceSpec{
+    Annotations: swarm.Annotations{
+      Name: name,
+    },
+    TaskTemplate: swarm.TaskSpec{
+      ContainerSpec: &swarm.ContainerSpec{
+        Image: "alpine",
+        Env: env,
+        Command: []string{ "ping", "docker.com" },
+      },
+      // RestartPolicy
+      // Networks
+    },
+    Mode: swarm.ServiceMode{
+      Replicated: &swarm.ReplicatedService{
+        Replicas: &replicas,
+      },
+    },
+  }
+
+  scopts := types.ServiceCreateOptions{
+    // QueryRegistry: true
+  }
+
+  ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+  _, err = cli.ServiceCreate(ctx, spec, scopts)
+  cancel()
+
+  if err != nil {
+    panic(err)
+  }
+
+	return nil, nil
+}
+
+func (*ClusterSwarmRunner) ID() string {
+	return "cluster:swarm"
+}
+
+func (*ClusterSwarmRunner) ConfigType() reflect.Type {
+	return reflect.TypeOf(ClusterSwarmRunnerConfig{})
+}
+
+func (*ClusterSwarmRunner) CompatibleBuilders() []string {
+	return []string{"docker:go"}
+}

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/logging"
 	"github.com/ipfs/testground/pkg/util"
 	"github.com/ipfs/testground/sdk/runtime"
@@ -18,7 +19,7 @@ import (
 )
 
 var (
-	_ Runner = &ClusterSwarmRunner{}
+	_ api.Runner = &ClusterSwarmRunner{}
 )
 
 // ClusterSwarmRunnerConfig is the configuration object of this runner. Boolean
@@ -26,12 +27,29 @@ var (
 type ClusterSwarmRunnerConfig struct {
 	// LogLevel sets the log level in the test containers (default: not set).
 	LogLevel string `toml:"log_level"`
+
+	// DockerEndpoint is the URL of the docker swarm manager endpoint, e.g.
+	// "tcp://manager:2376"
+	DockerEndpoint string `toml:"docker_endpoint"`
+
+	// DockerTLS indicates whether client TLS is enabled.
+	DockerTLS bool `toml:"docker_tls"`
+
+	// DockerTLSCACertPath is the path to the CA Certificate. Only used if
+	// DockerTLS = true.
+	DockerTLSCACertPath string `toml:"docker_tls_ca_cert_path"`
+
+	// DockerTLSCertPath is the path to our client cert, signed by the CA. Only
+	// used if DockerTLS = true.
+	DockerTLSCertPath string `toml:"docker_tls_cert_path"`
+
+	// DockerTLSKeyPath is our private key. Only used if DockerTLS = true.
+	DockerTLSKeyPath string `toml:"docker_tls_key_path"`
 }
 
 // defaultClusterSwarmConfig is the default configuration. Incoming configurations will be
 // merged with this object.
-var defaultClusterSwarmConfig = ClusterSwarmRunnerConfig{
-}
+var defaultClusterSwarmConfig = ClusterSwarmRunnerConfig{}
 
 // ClusterSwarmRunner is a runner that creates a Docker service to launch as
 // many replicated instances of a container as the run job indicates.
@@ -39,12 +57,12 @@ type ClusterSwarmRunner struct{}
 
 // TODO runner option to keep containers alive instead of deleting them after
 // the test has run.
-func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
+func (*ClusterSwarmRunner) Run(input *api.RunInput) (*api.RunOutput, error) {
 	var (
-		// image    = input.ArtifactPath
+		image    = input.ArtifactPath
 		seq      = input.Seq
 		deferred []func() error
-		log      = logging.S().With("runner", "cluster:swarm", "run_id", input.ID)
+		log      = logging.S().With("runner", "cluster:swarm", "run_id", input.RunID)
 	)
 
 	defer func() {
@@ -77,7 +95,7 @@ func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
 	runenv := &runtime.RunEnv{
 		TestPlan:           input.TestPlan.Name,
 		TestCase:           testcase.Name,
-		TestRun:            input.ID,
+		TestRun:            input.RunID,
 		TestCaseSeq:        seq,
 		TestInstanceCount:  input.Instances,
 		TestInstanceParams: input.Parameters,
@@ -91,62 +109,74 @@ func (*ClusterSwarmRunner) Run(input *Input) (*Output, error) {
 		env = append(env, "LOG_LEVEL="+cfg.LogLevel)
 	}
 
-  // Temp Redis fix
+	// Temp Redis fix
 	env = append(env, "REDIS_HOST=172.31.14.166")
 
 	// Create a docker client.
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	var opts []client.Opt
+	if cfg.DockerTLS {
+		opts = append(opts, client.WithTLSClientConfig(cfg.DockerTLSCACertPath, cfg.DockerTLSCertPath, cfg.DockerTLSKeyPath))
+	}
+
+	opts = append(opts, client.WithHost(cfg.DockerEndpoint))
+	opts = append(opts, client.WithAPIVersionNegotiation())
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	// Start service
-	// name := fmt.Sprintf("tg-%s-%s-%s", input.TestPlan.Name, testcase.Name, input.ID)
-	name := fmt.Sprintf("tg-%s-%s", input.TestPlan.Name, testcase.Name)
+	// Configure the service.
+	var (
+		sname    = fmt.Sprintf("tg-%s-%s-%s", input.TestPlan.Name, testcase.Name, input.RunID)
+		replicas = uint64(input.Instances)
+	)
 
-	log.Infow("creating service", "name", name)
+	log.Infow("creating service", "name", sname, "replicas", replicas)
 
-  // docker service create --replicas 1 --name helloworld alpine ping docker.com
+	spec := swarm.ServiceSpec{
+		Networks: []swarm.NetworkAttachmentConfig{
+			{Target: "data"},
+			{Target: "control"},
+		},
+		Mode: swarm.ServiceMode{
+			Replicated: &swarm.ReplicatedService{
+				Replicas: &replicas,
+			},
+		},
+		Annotations: swarm.Annotations{Name: sname},
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{
+				Image: image,
+				Env:   env,
+			},
+			RestartPolicy: &swarm.RestartPolicy{
+				Condition: swarm.RestartPolicyConditionNone,
+			},
+			Resources: &swarm.ResourceRequirements{
+				Reservations: &swarm.Resources{
+					MemoryBytes: 60 * 1024 * 1024,
+				},
+				Limits: &swarm.Resources{
+					MemoryBytes: 30 * 1024 * 1024,
+				},
+			},
+			Placement: &swarm.Placement{
+				MaxReplicas: 200,
+			},
+		},
+	}
 
-  replicas := uint64(input.Instances)
-  spec := swarm.ServiceSpec{
-    Annotations: swarm.Annotations{
-      Name: name,
-    },
-    TaskTemplate: swarm.TaskSpec{
-      ContainerSpec: &swarm.ContainerSpec{
-        Image: "909427826938.dkr.ecr.us-west-2.amazonaws.com/testground:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855@sha256:e175f10c2fc0545ede1de08458dffbea5b3efb3c023963028eac9129f4fd5920",
-        Env: env,
-      },
-      RestartPolicy: &swarm.RestartPolicy{
-        Condition: swarm.RestartPolicyConditionNone,
-      },
-      Networks: []swarm.NetworkAttachmentConfig{
-        {
-          Target: "hw6dcms11qhf3iv3rr2j8a2vb",
-        },
-      },
-    },
-    Mode: swarm.ServiceMode{
-      Replicated: &swarm.ReplicatedService{
-        Replicas: &replicas,
-      },
-    },
-  }
+	scopts := types.ServiceCreateOptions{QueryRegistry: true}
 
-  scopts := types.ServiceCreateOptions{
-    // QueryRegistry: true
-  }
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
 
-  ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-  _, err = cli.ServiceCreate(ctx, spec, scopts)
-  cancel()
+	resp, err := cli.ServiceCreate(ctx, spec, scopts)
+	if err != nil {
+		return nil, err
+	}
 
-  if err != nil {
-    panic(err)
-  }
-
-	return nil, nil
+	return &api.RunOutput{RunnerID: resp.ID}, nil
 }
 
 func (*ClusterSwarmRunner) ID() string {


### PR DESCRIPTION
I have an automated Ansible setup for Docker swarm in the aws-ansible branch (needs just a bit more cleanup). I first tested it with a shell script, but then I realized that it wouldn't be too much work to modify the local:docker runner to talk to the swarm API.

Here's a demo running the smlbench2 2-container bitswap test across 2 different EC2 vms in the Docker swarm cluster:

![tg-docker-swarm-runner](https://user-images.githubusercontent.com/20886/68005983-553beb80-fc34-11e9-801c-eaa0f046033e.gif)

https://github.com/ipfs/testground/blob/aws-ansible/pkg/runner/cluster_swarm.go

It's not quite done yet ... I've hard-coded the image (pulling from ECR), the REDIS_HOST environment variable, and the network. We'll want to upload the image to ECR after building it before creating the service.

-------------- 

Not complete yet ... some hard-coded values. See demo of it running in #110 (along with notes about what is still missing)

I just hacked this together to test the ansible setup I've been prototyping in the aws-ansible branch:

https://github.com/ipfs/testground/tree/aws-ansible

(tested with the smlbench2 test, which isn't on master yet ... that's going to be the basis of #94)