### PR TITLE
Fix locateSrcDir

### DIFF
--- a/pkg/engine/dirs.go
+++ b/pkg/engine/dirs.go
@@ -46,7 +46,6 @@ func locateSrcDir() (string, error) {
 
 	for len(path) > 1 {
 		fmt.Printf("attempting to guess testground base directory; for better control set ${%s}\n", EnvTestgroundSrcDir)
-		fmt.Println(path)
 		if isTestgroundRepo(path) {
 			os.Setenv(EnvTestgroundSrcDir, path)
 			fmt.Printf("successfully located testground base directory: %s\n", path)

--- a/pkg/engine/dirs.go
+++ b/pkg/engine/dirs.go
@@ -39,18 +39,20 @@ func locateSrcDir() (string, error) {
 	}
 
 	// 2. Fallback to the working directory.
-	path, err := os.Executable()
+	path, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 
 	for len(path) > 1 {
 		fmt.Printf("attempting to guess testground base directory; for better control set ${%s}\n", EnvTestgroundSrcDir)
-		if path = filepath.Dir(path); isTestgroundRepo(path) {
+		fmt.Println(path)
+		if isTestgroundRepo(path) {
 			os.Setenv(EnvTestgroundSrcDir, path)
 			fmt.Printf("successfully located testground base directory: %s\n", path)
 			return path, nil
 		}
+		path = filepath.Dir(path)
 	}
 
 	return "", ErrUnknownSrcDir

--- a/pkg/engine/dirs_test.go
+++ b/pkg/engine/dirs_test.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func removeEnvTestgroundSrcDir(tb testing.TB) func() {
+	if v, ok := os.LookupEnv(EnvTestgroundSrcDir); ok {
+		os.Unsetenv(EnvTestgroundSrcDir)
+		return func() { os.Setenv(EnvTestgroundSrcDir, v) }
+	}
+	// no-op
+	return func() {}
+}
+
+func setupFakeTestgroundRepo(tb testing.TB) (string, func()) {
+	content := []byte(`module github.com/ipfs/testground
+
+	go 1.13
+	`)
+	srcdir, err := ioutil.TempDir("", "testground")
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	tmpmod := filepath.Join(srcdir, "go.mod")
+	if err := ioutil.WriteFile(tmpmod, content, 0666); err != nil {
+		tb.Fatal(err)
+	}
+
+	return srcdir, func() { os.RemoveAll(srcdir) }
+}
+
+func Test_isTestgroundRepo(t *testing.T) {
+	srcdir, cleanup := setupFakeTestgroundRepo(t)
+	defer cleanup()
+
+	if isRepo := isTestgroundRepo(srcdir); !isRepo {
+		t.Fail()
+	}
+}
+
+func Test_locateSrcDir(t *testing.T) {
+	cleanEnv := removeEnvTestgroundSrcDir(t)
+	defer cleanEnv()
+
+	srcdir, cleanRepo := setupFakeTestgroundRepo(t)
+	defer cleanRepo()
+
+	err := os.Chdir(srcdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := locateSrcDir()
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	if got != srcdir {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Running `testground` in $GOPATH/src/github.com/ipfs/testground returned:
```
$ testground
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
attempting to guess testground base directory; for better control set ${TESTGROUND_SRCDIR}
panic: unable to determine testground src dir

goroutine 1 [running]:
github.com/ipfs/testground/cmd.glob..func1(0x0)
	/home/lanzafame/src/github.com/ipfs/testground/cmd/all.go:12 +0x5b
github.com/ipfs/testground/cmd.init()
	/home/lanzafame/src/github.com/ipfs/testground/cmd/all.go:15 +0x37
```

Discovered that `locateSrcDir` was getting the directory of the executable, instead of the working directory, i.e. where the executable was called, and it was also truncating the path before checking if it was the source directory. 