### PR TITLE
Add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.21.0
+    hooks:
+      - id: golangci-lint
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: master
+    hooks:
+      - id: go-fmt
+      - id: go-vet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,3 @@ repos:
     rev: v1.21.0
     hooks:
       - id: golangci-lint
-  - repo: git://github.com/dnephin/pre-commit-golang
-    rev: master
-    hooks:
-      - id: go-fmt
-      - id: go-vet

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+init:
+	pip install pre-commit --upgrade
+	pre-commit install --install-hooks

--- a/README.md
+++ b/README.md
@@ -84,7 +84,20 @@ Refer to the [specification](docs/SPEC.md) document.
 
 ## Contributing & Testing
 
-We kindly ask you to read through the SPEC first and give this project a run first in your local machine. It is a fast moving project at the moment and it might require some tinkering and experimentation to compesate the lack of documentation.
+We kindly ask you to read through the [SPEC](docs/SPEC.md) first and give this
+project a run first in your local machine. It is a fast moving project at the
+moment, and it might require some tinkering and experimentation to compensate
+for the lack of documentation.
+
+If you plan to contribute code, make sure to install the
+[pre-commit](https://github.com/pre-commit/pre-commit) tool, which manages our
+pre-commit hooks for things like linters, go fmt, go vet, etc.
+
+We provide a `Makefile` rule to facilitate the setup:
+
+```sh
+$ make init
+```
 
 ### Setup
 


### PR DESCRIPTION
* uses the fantastic pre-commit project to manage hooks: github.com/pre-commit/pre-commit
* introduces a Makefile to facilitate installation and initialisation of pre-commit for new devs.
* adds the following go hooks: golangci-lint.
* adds a few general sanity check hooks.
* enhances the README.