### PR TITLE
Proposal to separate Provisioning, Building and Running into separate Phases

### DIFF
--- a/docs/PLAN_SPEC.md
+++ b/docs/PLAN_SPEC.md
@@ -3,7 +3,7 @@
 Each testing **Plan** contains:
 - An **overview** of what we are looking to achieve with the test (roughly ~1 paragraph).
 - **What we are looking to expect to be able to optimize** by running this test and therefore, a suggestion of what are The data points that must be gathered in order to assess if an improvement or regression has been made.-
-- The **plan parameters**. This include both Network Parameters (e.g. Number of Nodes) and Image Parameters (e.g. bucket_size, bitswap strategy, etc)
+- The **plan parameters**. This include both Network Parameters (e.g. Number of Nodes) and Image Parameters (e.g. bucket_size, bitswap strategy, etc). These show up on the plan manifest.toml
 - The Tests. Each contains
   - A set of **test parameters** that are customizable for each test.
   - A **narrative** for each Test that describes on how the network will set up itself (_Warm Up_ phase) and how the actors will play their multiple roles (in _Acts_).
@@ -21,19 +21,28 @@ Each testing **Plan** contains:
 
 ## Plan Parameters
 
-- **Network Parameters**
-  - `Region` - Region or Regions where the test should be run at (default to single region)
-- **Image Parameters**
-  - b
+- **Base**
+  - `name` - The name of the plan
+  - `plan-source` - Where to find the source code for the plan
+  - `defaults` - The default provisioner, builder and runner
+- **Provision**
+  - `aws-region` - One or more aws regions where the test should be run at (default to single region)
+  - `machine-size` - The type of machine to instantiate
+- **Builder**
+  - `go-ipfs-version` - The version of go-ipfs to get built
+- **Runner**
+  - `instances` - number of instances
+  - `bandwidth` - The bandwidth that each runner should have available
 
 ## Tests
 
 ### `Test:` _NAME_
 
-- **Test Parameters**
+**Test Parameters**
   - n/a
-- **Narrative**
-  - **Warm up**
+
+**Narrative**
+  - **Warm up / Set up Phase**
     - a
   - **Act I**
     - b

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -1,62 +1,81 @@
+[[base]]
 name = "dht"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
+# hashicorp/go-getter URLs, so in the future we fetch plans from anywhere
 source_path = "file:${TESTGROUND_SRCDIR}/plans/dht"
+    [defaults]
+    provisioner = "terraform:aws"
+    builder = "docker:go"
+    runner = "local:docker"
 
-[build_strategies."docker:go"]
-enabled = true
-go_version = "1.13"
-module_path = "github.com/ipfs/testground/plans/dht"
-exec_pkg = "."
+[[provisioners]]
+    [provisioner_strategies. "vagrant:local"]
+    enabled = true
 
-# TODO: exec:go is not ready yet
-[build_strategies."exec:go"]
-enabled = true
-module_path = "github.com/ipfs/testground/plans/dht"
-exec_pkg = "."
+    [provisioner_strategies. "terraform:aws"]
+    enabled = true
 
-[run_strategies."local:docker"]
-enabled = true
+    [provisioner_strategies. "terraform:aws:docker-swarm"]
+    enabled = true
 
-[run_strategies."local:exec"]
-enabled = true
+    [provisioner_strategies. "terraform:do"]
+    enabled = true
 
-[run_strategies."cluster:swarm"]
-enabled = true
+    [provisioner_strategies. "ansible:aws"]
+    enabled = true
+
+    [provisioner_strategies. "neighboors:boxes"]
+    enabled = true
+
+[[builders]]
+    [build_strategies."docker:go"]
+    enabled = true
+    go_version = "1.13"
+    exec_pkg = "."
+
+    [build_strategies."packer:go"]
+    enabled = true
+    go_version = "1.13"
+    exec_pkg = "."
+
+    # TODO: exec:go is not ready yet
+    [build_strategies."exec:go"]
+    enabled = false
+    exec_pkg = "."
+
+[[runners]]
+instances = { min = 2, max = 200, default = 25 }
+    [run_strategies."docker:go"]
+    enabled = true
+
+    [run_strategies."exec:go"]
+    enabled = true
 
 # seq 0
 [[testcases]]
 name = "find-peers"
-instances = { min = 2, max = 200, default = 25 }
 
-  [testcases.params]
-  auto_refresh = { type = "bool", desc = "", unit = "bool" }
-  random_walk = { type = "bool", desc = "", unit = "bool" }
-  bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
-  n_find_peers = { type = "int", desc = "number of peers to find", unit = "peers" }
-  timeout_secs = { type = "int", desc = "timeout", unit = "seconds"}
+    [testcases.params]
+    auto_refresh = { type = "bool", desc = "", unit = "bool" }
+    random_walk = { type = "bool", desc = "", unit = "bool" }
+    bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
+    n_find_peers = { type = "int", desc = "number of peers to find", unit = "peers" }
+    timeout_secs = { type = "int", desc = "timeout", unit = "seconds"}
 
 # seq 1
 [[testcases]]
 name = "find-providers"
-instances = { min = 2, max = 250, default = 25 }
-
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
 
 # seq 2
 [[testcases]]
 name = "provide-stress"
-instances = { min = 2, max = 250, default = 25 }
-
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
 
 # seq 3
 [[testcases]]
 name = "store-get-value"
-instances = { min = 2, max = 250, default = 25 }
 roles = ["storer", "fetcher"]
-
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }


### PR DESCRIPTION
@raulk this is where my head was headed a bit ago. The PR adds some light touches to a Plan config and a Plan spec. The general idea is:

- Create a separate option for Provisioning
- Separate the elements of the provision step out of the runner (i.e. running in a cluster of docker swarm nodes or multiple docker containers is effectively the same thing for the runner, what changes is the provisioning sets up that cluster)
- We keep a Vagrant provisioner so that we can have a reproducible env in all architectures
- We keep the option open to treat some pre-provisioned "neighboor:boxes" to run our tests.
- This also helps map a plan spec to the actual plan manifest

