### PR TITLE
feat(runner): separate control and per-run data networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-getter v1.4.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.7
 	github.com/ipfs/testground/sdk/runtime v0.0.0-20190921111954-a84ff142a5a3
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,11 +71,15 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-getter v1.4.0 h1:ENHNi8494porjD0ZhIrjlAHnveSFhY7hvOJrV/fsKkw=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 
-	"github.com/google/uuid"
 	"github.com/imdario/mergo"
 	"github.com/logrusorgru/aurora"
 )
@@ -130,26 +129,30 @@ func (*LocalDockerRunner) Run(input *api.RunInput) (*api.RunOutput, error) {
 		return nil, err
 	}
 
-	// Create a user-defined bridge. We will attach the redis container, as well
-	// as all test containers to it.
-	networkID, err := newUserDefinedBridge(cli)
+	dataNetworkID, err := newDataNetwork(cli, runenv, "default")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := cli.NetworkRemove(ctx, dataNetworkID); err != nil {
+			log.Errorw("removing network", "network", dataNetworkID, "error", err)
+		}
+	}()
+
+	// Ensure we have a control network.
+	controlNetworkID, err := ensureControlNetwork(cli, log)
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure that we have a testground-redis container; if not, we'll create
 	// it.
-	redisContainerID, err := ensureRedisContainer(cli, log)
+	_, err = ensureRedisContainer(cli, log, controlNetworkID)
 	if err != nil {
 		return nil, err
 	}
-
-	// Attach the testground-redis container to the user-defined bridge.
-	_, err = attachContainerToNetwork(cli, redisContainerID, networkID)
-	if err != nil {
-		return nil, err
-	}
-	// deferred = append(deferred, detach)
 
 	// Start as many containers as test case instances.
 	var containers []string
@@ -161,9 +164,14 @@ func (*LocalDockerRunner) Run(input *api.RunInput) (*api.RunOutput, error) {
 		ccfg := &container.Config{
 			Image: image,
 			Env:   env,
+			Labels: map[string]string{
+				"testground.plan":     input.TestPlan.Name,
+				"testground.testcase": testcase.Name,
+				"testground.runid":    input.RunID,
+			},
 		}
 		hcfg := &container.HostConfig{
-			NetworkMode: container.NetworkMode(networkID),
+			NetworkMode: container.NetworkMode(controlNetworkID),
 		}
 
 		// Create the container.
@@ -174,7 +182,14 @@ func (*LocalDockerRunner) Run(input *api.RunInput) (*api.RunOutput, error) {
 		if err != nil {
 			break
 		}
+
 		containers = append(containers, res.ID)
+
+		// TODO: Remove this when we get the sidecar working. It'll do this for us.
+		_, err = attachContainerToNetwork(cli, res.ID, dataNetworkID)
+		if err != nil {
+			break
+		}
 	}
 
 	if !cfg.KeepContainers {
@@ -295,15 +310,27 @@ func deleteContainers(cli *client.Client, log *zap.SugaredLogger, ids []string) 
 	return err
 }
 
-func newUserDefinedBridge(cli *client.Client) (id string, err error) {
+func ensureControlNetwork(cli *client.Client, log *zap.SugaredLogger) (id string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	uuid, err := uuid.NewRandom()
+	networks, err := cli.NetworkList(ctx, types.NetworkListOptions{
+		Filters: filters.NewArgs(filters.Arg("name", "testground-control")),
+	})
 	if err != nil {
-		return "", err
+		return "", nil
 	}
-	res, err := cli.NetworkCreate(ctx, uuid.String(), types.NetworkCreate{
+
+	if len(networks) > 0 {
+		network := networks[0]
+
+		log.Infow("control container found", "networkID", network.ID)
+
+		return network.ID, nil
+	}
+
+	res, err := cli.NetworkCreate(ctx, "testground-control", types.NetworkCreate{
+		Internal:   true,
 		Driver:     "bridge",
 		Attachable: true,
 	})
@@ -313,8 +340,33 @@ func newUserDefinedBridge(cli *client.Client) (id string, err error) {
 	return res.ID, nil
 }
 
+func newDataNetwork(cli *client.Client, env *runtime.RunEnv, name string) (id string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, err := cli.NetworkCreate(
+		ctx,
+		fmt.Sprintf("tg-%s-%s-%s-%s", env.TestPlan, env.TestCase, env.TestRun, name),
+		types.NetworkCreate{
+			Internal:   true,
+			Driver:     "bridge",
+			Attachable: true,
+			Labels: map[string]string{
+				"testground.plan":     env.TestPlan,
+				"testground.testcase": env.TestCase,
+				"testground.runid":    env.TestRun,
+				"testground.name":     name,
+			},
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	return res.ID, nil
+}
+
 // ensureRedisContainer ensures there's a testground-redis container started.
-func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger) (id string, err error) {
+func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger, controlNetwork string) (id string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -334,6 +386,14 @@ func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger) (id string
 
 		log.Infow("redis container found",
 			"containerId", container.ID, "state", container.State)
+
+		if len(container.NetworkSettings.Networks) != 1 {
+			return "", fmt.Errorf("redis container should have exactly one network; consider deleting container %s", container.ID)
+		}
+
+		if net, ok := container.NetworkSettings.Networks["testground-control"]; !ok || net.NetworkID != controlNetwork {
+			return "", fmt.Errorf("expected redis container to be connected to the testground control network; consider deleting container %s", container.ID)
+		}
 
 		switch container.State {
 		case "running":
@@ -373,7 +433,9 @@ func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger) (id string
 		Image:      "redis",
 		Entrypoint: []string{"redis-server"},
 		Cmd:        []string{"--notify-keyspace-events", "$szxK"},
-	}, nil, nil, "testground-redis")
+	}, &container.HostConfig{
+		NetworkMode: container.NetworkMode(controlNetwork),
+	}, nil, "testground-redis")
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
1. Use separate control/data networks everywhere.
2. Create a new data network for every run.

I've tested the local docker runner changes but am unsure how to test it on AWS.