### PR TITLE
Fix several bugs in the `cluster:swarm` runner

### DIFF
--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -138,10 +138,10 @@ func (*ClusterSwarmRunner) Run(input *api.RunInput) (*api.RunOutput, error) {
 	networkSpec := types.NetworkCreate{
 		Driver:         "overlay",
 		CheckDuplicate: true,
-		EnableIPv6:     true, // TODO: params?
-		Internal:       true,
-		Attachable:     true,
-		Scope:          "swarm",
+		// EnableIPv6:     true, // TODO(steb): this breaks.
+		Internal:   true,
+		Attachable: true,
+		Scope:      "swarm",
 		Labels: map[string]string{
 			"testground.plan":     input.TestPlan.Name,
 			"testground.testcase": testcase.Name,


### PR DESCRIPTION
* Fix the `rm_service` flag. mergo and boolean zero values don't get along. We now default to all boolean flags having semantics such that the default value is false.
* Remove the IPv6 configuration that was breaking in AWS, and we don't need it now.
