### PR TITLE
Infra Lead Responsibilities Handoff.initiate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ The current TestGround Team is composed of:
 
 - @raulk - Lead Architect, Engineer, Developer
 - @daviddias - Engineer, Developer, acting as interim PM for the project
-- @jimpick - Engineer, Developer, Infrastructure Lead
-- @nonsense - Engineer, Developer, TestGround as a Service Lead
-- Soon™ @hacdias - Engineer, Developer
+- @nonsense - Engineer, Developer, TestGround as a Service / Infrastructure Lead
+- @jimpick - Engineer, Developer
+- @stebalien - Engineer, Developer
+- @hacdias - Engineer, Developer
 - you! Yes, you can contribute as well, however, do understand that this is a brand new and fast moving project and so contributing might require extra time to onboard
 
 To learn how this team works together read [HOW_WE_WORK](./docs/HOW_WE_WORK.md)


### PR DESCRIPTION
@nonsense, just came out of a chat with @jimpick and we found that now that you have been onboarded to the project and are tacking more and more responsibility in how TestGround provides a complete Service to the team, it makes sense (as it was planned) for you to also own the work that @jimpick has valiantly championed for us, getting us with a Cluster that we can use, even though it was not is bread and butter.

@jimpick will more focused on develping Test Plans, starting with #96 and then expanding his scope to think about developer experience, onboarding (docs, demos) and overall, making sure we make writing Test Plans super simple and fun.


For a good handoff, @jimpick please write down a brain dump of:
- Where Infra is today
- Where it needs to be
- What are still some of the open questions
- What are things we have decided not to build
- Other considerations that @nonsense should no

Then, ensure that @nonsense has access to all the admin panels (AWS, Elastic Search, etc).

Once this is written down, I propose that @jimpick and @nonsense have a __recorded__ Zoom call in which you go through all of it, with @nonsense following and asking question + replicating the steps, similar to the walk through from @raulk back in September. Once that is done, share it with the team so that we all can learn as well. 