### PR TITLE
docs: fix make command and make makefile cross-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 pre-commit:
-	pip install pre-commit --upgrade
+	python -m pip install pre-commit --upgrade
 	pre-commit install --install-hooks

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you plan to contribute code, make sure to install the [pre-commit](https://gi
 We provide a `Makefile` rule to facilitate the setup:
 
 ```sh
-$ make init
+$ make pre-commit
 ```
 
 [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
1. Updates the makefile to make it more cross-platform (`pip` --> `python -m pip`). The official documentation now [recommends](https://bugs.python.org/issue22295) the latter.
2. Updates the README make command to `make pre-commit`.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>