### PR TITLE
feat: add support for array of strings and json parameters

### DIFF
--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -287,7 +287,6 @@ func (re *RunEnv) JSONParam(name string, v interface{}) (ok bool) {
 	}
 
 	if err := json.Unmarshal([]byte(s), v); err != nil {
-		fmt.Println(err)
 		return false
 	}
 

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -287,6 +287,7 @@ func (re *RunEnv) JSONParam(name string, v interface{}) (ok bool) {
 	}
 
 	if err := json.Unmarshal([]byte(s), v); err != nil {
+		fmt.Println(err)
 		return false
 	}
 

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"crypto/sha1"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -256,6 +257,40 @@ func (re *RunEnv) BooleanParamD(name string, def bool) bool {
 		return def
 	}
 	return b
+}
+
+// StringArrayParam returns an array of string parameter, or an empty array
+// if it does not exist. The second returns value indicates if the parameter
+// was (un)set or (in)valid.
+func (re *RunEnv) StringArrayParam(name string) (a []string, ok bool) {
+	a = []string{}
+	ok = re.JSONParam(name, &a)
+	return a, ok
+}
+
+// StringArrayParamD returns an array of string parameter or the default one
+// if the parameter was not set or is invalid.
+func (re *RunEnv) StringArrayParamD(name string, def []string) []string {
+	a := []string{}
+	if ok := re.JSONParam(name, &a); !ok {
+		return def
+	}
+	return a
+}
+
+// JSONParam unmarshals a JSON parameter in an arbitrary interface.
+// It returns if the parameter was (un)set or (in)valid.
+func (re *RunEnv) JSONParam(name string, v interface{}) (ok bool) {
+	s, ok := re.TestInstanceParams[name]
+	if !ok {
+		return false
+	}
+
+	if err := json.Unmarshal([]byte(s), v); err != nil {
+		return false
+	}
+
+	return true
 }
 
 // // ExtractRunEnv extracts the test context from a context.Context object.


### PR DESCRIPTION
This adds support for two new different types of test parameters and fixes #195.

1. Array of Strings, through the functions:
	- `func StringArrayParam(name string) (a []string, ok bool)`
	- `func StringArrayParamD(name string, def []string) []string`
2. And arbitrary JSON structures:
	- `func JSONParam(name string, v interface{}) (ok bool)`

---

In reality, `StringArrayParam` and `StringArrayParamD` are just wrappers for `JSONParam`. 

I didn't add `IntArrayParam` nor `BoolArrayParam` because I think they are more uncommon. However, I'm open to see what you've to say!

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>