### PR TITLE
feat: track dependency tree

### DIFF
--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -49,4 +49,6 @@ type BuildOutput struct {
 	// ArtifactPath can be the docker image ID, a file location, etc. of the
 	// resulting artifact. It is builder-dependent.
 	ArtifactPath string
+	// Dependencies is a map of modules (as keys) to versions (as values).
+	Dependencies map[string]string
 }

--- a/pkg/build/golang/Dockerfile.template
+++ b/pkg/build/golang/Dockerfile.template
@@ -22,7 +22,7 @@ ENV TESTPLAN_EXEC_PKG ${TESTPLAN_EXEC_PKG}
 ENV PLAN_DIR /plan/
 
 # Optionally install IPFS
-RUN if [ -n "${GO_IPFS_VERSION}" ]; then echo Install IPFS ${GO_IPFS_VERSION} && cd /tmp && wget https://dist.ipfs.io/go-ipfs/v${GO_IPFS_VERSION}/go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz && tar xf go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz; fi 
+RUN if [ -n "${GO_IPFS_VERSION}" ]; then echo Install IPFS ${GO_IPFS_VERSION} && cd /tmp && wget https://dist.ipfs.io/go-ipfs/v${GO_IPFS_VERSION}/go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz && tar xf go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz; fi
 RUN touch /tmp/delete_me
 
 # Copy only go.mod files and download deps, in order to leverage Docker caching.
@@ -44,6 +44,10 @@ RUN cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
     && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o testplan ${TESTPLAN_EXEC_PKG}
 
+# Store module dependencies
+RUN cd ${PLAN_DIR} \
+  && go list -m all > ./testground_dep_list
+
 #:::
 #::: RUNTIME CONTAINER
 #:::
@@ -51,6 +55,7 @@ RUN cd ${PLAN_DIR} \
 #FROM busybox:1.31.0-glibc # Doesn't work with prebuilt IPFS binaries
 FROM debian
 
+COPY --from=0 /plan/testground_dep_list /
 COPY --from=0 /plan/testplan /
 RUN mkdir -p /usr/local/bin
 COPY --from=0 /tmp/delete_me /tmp/go-ipfs/ipfs* /usr/local/bin/

--- a/pkg/build/golang/Dockerfile.template
+++ b/pkg/build/golang/Dockerfile.template
@@ -46,7 +46,7 @@ RUN cd ${PLAN_DIR} \
 
 # Store module dependencies
 RUN cd ${PLAN_DIR} \
-  && go list -m all > ./testground_dep_list
+  && go list -m all > /testground_dep_list
 
 #:::
 #::: RUNTIME CONTAINER
@@ -55,7 +55,7 @@ RUN cd ${PLAN_DIR} \
 #FROM busybox:1.31.0-glibc # Doesn't work with prebuilt IPFS binaries
 FROM debian
 
-COPY --from=0 /plan/testground_dep_list /
+COPY --from=0 /testground_dep_list /
 COPY --from=0 /plan/testplan /
 RUN mkdir -p /usr/local/bin
 COPY --from=0 /tmp/delete_me /tmp/go-ipfs/ipfs* /usr/local/bin/

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -1,0 +1,87 @@
+package golang
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+func parseDependencies(raw string) map[string]string {
+	rawModules := strings.Split(raw, "\n")
+	modules := map[string]string{}
+
+	for _, module := range rawModules {
+		module = strings.TrimSpace(module)
+		if module == "" {
+			continue
+		}
+
+		parts := strings.Split(module, " ")
+		path := strings.TrimSpace(parts[0])
+		version := ""
+
+		if len(parts) == 2 {
+			version = strings.TrimSpace(parts[1])
+		}
+
+		modules[path] = version
+	}
+
+	return modules
+}
+
+func parseDependenciesFromDocker(cli *client.Client, imageID string) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ccfg := &container.Config{
+		Image: imageID,
+		Tty:   true,
+		Entrypoint: []string{
+			"cat",
+			"/testground_dep_list",
+		},
+	}
+
+	// Create container
+	res, err := cli.ContainerCreate(ctx, ccfg, nil, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Start container
+	err = cli.ContainerStart(ctx, res.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Get logs
+	reader, err := cli.ContainerLogs(ctx, res.ID, types.ContainerLogsOptions{
+		ShowStdout: true,
+		Since:      "2019-01-01T00:00:00",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	dependencies := buf.String()
+
+	// Remove container
+	err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
+	if err != nil {
+		return nil, err
+	}
+
+	return parseDependencies(dependencies), nil
+}

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -39,21 +39,18 @@ func parseDependencies(raw string) map[string]string {
 }
 
 func parseDependenciesFromDocker(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, imageID string) (map[string]string, error) {
-	// Create container
 	res, err := cli.ContainerCreate(ctx, &container.Config{Image: imageID}, nil, nil, "")
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		// Remove container
 		err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
 		if err != nil {
 			log.Warnf("error while removing container %s: %v", res.ID, err)
 		}
 	}()
 
-	// Copy file from container
 	tar, _, err := cli.CopyFromContainer(ctx, res.ID, "/testground_dep_list")
 	if err != nil {
 		return nil, err
@@ -65,7 +62,6 @@ func parseDependenciesFromDocker(ctx context.Context, log *zap.SugaredLogger, cl
 	}
 	defer os.RemoveAll(dir)
 
-	// Unpack the file
 	err = archive.Untar(tar, dir, &archive.TarOptions{NoLchown: true})
 	if err != nil {
 		return nil, err

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -39,10 +38,7 @@ func parseDependencies(raw string) map[string]string {
 	return modules
 }
 
-func parseDependenciesFromDocker(cli *client.Client, imageID string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
+func parseDependenciesFromDocker(ctx context.Context, cli *client.Client, imageID string) (map[string]string, error) {
 	// Create container
 	res, err := cli.ContainerCreate(ctx, &container.Config{Image: imageID}, nil, nil, "")
 	if err != nil {

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
+	"go.uber.org/zap"
 )
 
 func parseDependencies(raw string) map[string]string {
@@ -38,7 +38,7 @@ func parseDependencies(raw string) map[string]string {
 	return modules
 }
 
-func parseDependenciesFromDocker(ctx context.Context, cli *client.Client, imageID string) (map[string]string, error) {
+func parseDependenciesFromDocker(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, imageID string) (map[string]string, error) {
 	// Create container
 	res, err := cli.ContainerCreate(ctx, &container.Config{Image: imageID}, nil, nil, "")
 	if err != nil {
@@ -49,7 +49,7 @@ func parseDependenciesFromDocker(ctx context.Context, cli *client.Client, imageI
 		// Remove container
 		err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
 		if err != nil {
-			fmt.Printf("error while removing container %s: %v", res.ID, err)
+			log.Warnf("error while removing container %s: %v", res.ID, err)
 		}
 	}()
 

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -48,6 +49,14 @@ func parseDependenciesFromDocker(cli *client.Client, imageID string) (map[string
 		return nil, err
 	}
 
+	defer func() {
+		// Remove container
+		err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
+		if err != nil {
+			fmt.Printf("error while removing container %s: %v", res.ID, err)
+		}
+	}()
+
 	// Copy file from container
 	tar, _, err := cli.CopyFromContainer(ctx, res.ID, "/testground_dep_list")
 	if err != nil {
@@ -70,12 +79,5 @@ func parseDependenciesFromDocker(cli *client.Client, imageID string) (map[string
 	if err != nil {
 		return nil, err
 	}
-
-	// Remove container
-	err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
-	if err != nil {
-		return nil, err
-	}
-
 	return parseDependencies(string(deps)), nil
 }

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -24,7 +24,7 @@ func parseDependencies(raw string) map[string]string {
 			continue
 		}
 
-		parts := strings.Split(module, " ")
+		parts := strings.SplitN(module, " ", 2)
 		path := strings.TrimSpace(parts[0])
 		version := ""
 

--- a/pkg/build/golang/deps_test.go
+++ b/pkg/build/golang/deps_test.go
@@ -1,0 +1,51 @@
+package golang
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var testParseDependencies = []struct {
+	input  string
+	output map[string]string
+}{
+	{
+		input: `example.com/module/a v1.2`,
+		output: map[string]string{
+			"example.com/module/a": "v1.2",
+		},
+	},
+	{
+		input: `example.com/module/a v1.2
+
+example.com/module/b v2.2`,
+		output: map[string]string{
+			"example.com/module/a": "v1.2",
+			"example.com/module/b": "v2.2",
+		},
+	},
+	{
+		input: `example.com/module/a v0.0.0-hashsomething
+example.com/module/b v1.2.4
+example.com/module/c v2.0.0
+example.com/module/d v2.0.0 => ./sdk/runtime`,
+		output: map[string]string{
+			"example.com/module/a": "v0.0.0-hashsomething",
+			"example.com/module/b": "v1.2.4",
+			"example.com/module/c": "v2.0.0",
+			"example.com/module/d": "v2.0.0 => ./sdk/runtime",
+		},
+	},
+}
+
+func TestParseDependencies(t *testing.T) {
+	for i, test := range testParseDependencies {
+		val := parseDependencies(test.input)
+
+		if !reflect.DeepEqual(val, test.output) {
+			fmt.Print(val)
+			t.Errorf("Incorrect value on parseDependencies for test %d", i)
+		}
+	}
+}

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -235,7 +235,7 @@ func (b *DockerGoBuilder) Build(in *api.BuildInput, output io.Writer) (*api.Buil
 		return nil, err
 	}
 
-	deps, err := parseDependenciesFromDocker(cli, in.BuildID)
+	deps, err := parseDependenciesFromDocker(ctx, cli, in.BuildID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list module dependencies; %w", err)
 	}

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -235,7 +235,15 @@ func (b *DockerGoBuilder) Build(in *api.BuildInput, output io.Writer) (*api.Buil
 		return nil, err
 	}
 
-	out := &api.BuildOutput{ArtifactPath: in.BuildID}
+	deps, err := parseDependenciesFromDocker(cli, in.BuildID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list module dependencies; %w", err)
+	}
+
+	out := &api.BuildOutput{
+		ArtifactPath: in.BuildID,
+		Dependencies: deps,
+	}
 
 	if cfg.PushRegistry {
 		if cfg.RegistryType != "aws" {

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -235,7 +235,7 @@ func (b *DockerGoBuilder) Build(in *api.BuildInput, output io.Writer) (*api.Buil
 		return nil, err
 	}
 
-	deps, err := parseDependenciesFromDocker(ctx, cli, in.BuildID)
+	deps, err := parseDependenciesFromDocker(ctx, log, cli, in.BuildID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list module dependencies; %w", err)
 	}

--- a/pkg/build/golang/exec.go
+++ b/pkg/build/golang/exec.go
@@ -133,7 +133,17 @@ func (b *ExecGoBuilder) Build(input *api.BuildInput, output io.Writer) (*api.Bui
 		return nil, fmt.Errorf("failed to run the build; %w", err)
 	}
 
-	return &api.BuildOutput{ArtifactPath: path}, nil
+	cmd = exec.Command("go", "list", "-m", "all")
+	cmd.Dir = plandst
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list module dependencies; %w", err)
+	}
+
+	return &api.BuildOutput{
+		ArtifactPath: path,
+		Dependencies: parseDependencies(string(out)),
+	}, nil
 }
 
 func (*ExecGoBuilder) ID() string {


### PR DESCRIPTION
This closes #147. Adds support for tracking the dependency graph changes by adding a new `Dependencies` variable into `BuildOutput`. It contains a map in the format module=>version. It allows for easy checks of versions changes and/or if a module was added/removed.

Note that in Docker mode, if the image is cached, nothing will be printed, and hence the dependencies map will be empty. Not sure if it's supposed to be this way or not, so I'll wait for your feedback!

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>