### PR TITLE
create route53 hosted zone for testground.ipfs.team

### DIFF
--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -1,6 +1,6 @@
-# Terraform: TestGround DNS
+# Terraform: Testground DNS
 
-A list of DNS zones used by the TestGround team:
+A list of DNS zones used by the Testground team:
 
 | Cloud | DNS Zone                                     |
 | ----- | -------------------------------------------- |

--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -6,3 +6,7 @@ A list of DNS zones used by the Testground team:
 | ----- | -------------------------------------------- |
 | AWS   | [testground.ipfs.team](testground.ipfs.team) |
 
+## Testground website
+
+Currently the Testground website lives at http://testground.ipfs.team and it redirects to our Github repo
+

--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -1,0 +1,8 @@
+# Terraform: TestGround DNS
+
+A list of DNS zones used by the TestGround team:
+
+| Cloud | DNS Zone                                     |
+| ----- | -------------------------------------------- |
+| AWS   | [testground.ipfs.team](testground.ipfs.team) |
+

--- a/infra/dns/testground.ipfs.team/main.tf
+++ b/infra/dns/testground.ipfs.team/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+    bucket = "terraform-backend-testground"
+    key    = "dns/testground.ipfs.team/backend.tfstate"
+    region = "eu-central-1"
+  }
+}
+
+provider "aws" {
+  region  = "eu-central-1"
+  version = "~> 2.41"
+}
+
+variable "default_tags" {
+  type = map
+
+  default = {
+    Environment = "production"
+    Team        = "testground"
+  }
+}
+
+resource "aws_route53_zone" "testground_ipfs_team" {
+  name = "testground.ipfs.team"
+  tags = merge(var.default_tags)
+}
+
+output "testground_ipfs_team_zone_id" {
+  value = "${aws_route53_zone.testground_ipfs_team.zone_id}"
+}
+

--- a/infra/dns/testground.ipfs.team/website.tf
+++ b/infra/dns/testground.ipfs.team/website.tf
@@ -1,0 +1,28 @@
+variable "domain" {
+  default = "testground.ipfs.team"
+}
+
+variable "redirect" {
+  default = "https://github.com/ipfs/testground"
+}
+
+resource "aws_s3_bucket" "redirect" {
+  bucket = var.domain
+  acl    = "private"
+
+  website {
+    redirect_all_requests_to = var.redirect
+  }
+}
+
+resource "aws_route53_record" "testground_ipfs_team" {
+  name    = var.domain
+  zone_id = aws_route53_zone.testground_ipfs_team.zone_id
+  type    = "A"
+
+  alias {
+    name                   = aws_s3_bucket.redirect.website_domain
+    zone_id                = aws_s3_bucket.redirect.hosted_zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
This PR is adding Terraform playbooks to manage a hosted zone for `testground.ipfs.team` in AWS. I have already applied the playbooks, so the backend has been created in S3 and the hosted zone exists.

We need to add docs to point to the correct account on AWS where this is hosted, but for now this information is implicit, until we have some valuable records there (for example our website, or record for the production TestGround service, or something else.)

Next steps:
- [x] Update `ipfs.team` domain to point the `testground` subdomain to AWS Route53.