### PR TITLE
Add Makefile to build ipfs/testground image (don't pull it)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 pre-commit:
 	python -m pip install pre-commit --upgrade
 	pre-commit install --install-hooks
+
+docker-ipfs-testground:
+	docker build -t ipfs/testground .

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -72,6 +72,12 @@ smlbench/simple-add
 smlbench/simple-add-get
 ```
 
+Before you run your first test, you need to build a Docker image that provides the "sidecar"
+
+```
+> make docker-ipfs-testground
+```
+
 This next command is your first test! It runs the lookup-peers test from the DHT plan, using the builder (which sets up the environment + compilation) named docker:go (which compiles go inside docker) and runs it using the runner local:docker (which runs on your local machine).
 
 ```

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -342,6 +342,7 @@ func setupGoProxy(ctx context.Context, log *zap.SugaredLogger, cli *client.Clien
 				Mounts:      []mount.Mount{mnt},
 				NetworkMode: container.NetworkMode(buildNetworkID),
 			},
+			PullImageIfMissing: true,
 		})
 		if err != nil {
 			warn = fmt.Errorf("[go_proxy_mode=local] error while creating goproxy container: %w; falling back to go_proxy_mode=direct", err)


### PR DESCRIPTION
Run `make docker-ipfs-testground` to build the docker image locally.

I've modified EnsureContainer() to take a PullImageIfMissing boolean
option - it is set to false for the ipfs/testground image, so it
will not automatically pull it from Docker Hub.

If the image does not exist, it displays the following error:

> Docker image ipfs/testground not found, run `make docker-ipfs-testground`