### PR TITLE
use aws credentials only if set

### DIFF
--- a/pkg/aws/ecr.go
+++ b/pkg/aws/ecr.go
@@ -24,8 +24,15 @@ type ecrsvc struct{}
 
 // newService creates a new ECR backend service stub.
 func (*ecrsvc) newService(cfg config.AWSConfig) (*ecr.ECR, error) {
-	creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey, "")
-	config := aws.NewConfig().WithRegion(cfg.Region).WithCredentials(creds)
+	config := aws.NewConfig()
+	if cfg.Region != "" {
+		config = config.WithRegion(cfg.Region)
+	}
+
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		creds := credentials.NewStaticCredentials(cfg.AccessKeyID, cfg.SecretAccessKey, "")
+		config = config.WithCredentials(creds)
+	}
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We don't have to set AWS credentials when there are other ways to authenticate and get authorisation for a given AWS API.

When `testground` runs as a `daemon` in AWS, the instance itself would have a role, which allows it to query AWS ECR, so we wouldn't have to generate credentials and configure them in the `.env.toml`.

This PR is basically changing the way we create an AWS client, by only using the static credentials if they have been set.