### PR TITLE
docs: overview section with testground daemon intro

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,15 @@
+# Testground Overview
+
+Testground is a tool for testing next generation P2P applications (i.e. Filecoin, IPFS, libp2p & others).
+
+## Testground Architecture
+
+Testground uses a client-server architecture. The Testground client talks to the Testground daemon, which builds a given test plan, and runs it. The Testground client and daemon can run on the same system, or you can connect a Testground client to a remote Testground daemon. The Testground client and daemon communicate using a REST API, over UNIX sockets or a network interface.
+
+### The Testground daemon
+
+The Testground daemon listens for Testground API requests and manages Testground test plan builds and runs.
+
+### The Testground client
+
+The Testground client is the primary way that users interact with Testground. When you use commands such as `testground run`, the client sends these commands to daemon, which executes them. The `testground` command uses the Testground API.

--- a/docs/PLAN_SPEC.md
+++ b/docs/PLAN_SPEC.md
@@ -50,7 +50,7 @@ Each testing **Plan** contains:
 
 ## Testing Plans MVP
 
-The testing Plans linked below have been identified as the most valuable sets of tests to implement for the Testground MVP. The goal of delivering a good characterization of the performance of IPFS in specific areas that can bolster our confidence level in shipping high quality releases of go-ipfs. Once the first 10 test Plans are written and TestGround fully deployed and operation, we will continue expanding the types of tests available.
+The testing Plans linked below have been identified as the most valuable sets of tests to implement for the Testground MVP. The goal of delivering a good characterization of the performance of IPFS in specific areas that can bolster our confidence level in shipping high quality releases of go-ipfs. Once the first 10 test Plans are written and Testground fully deployed and operation, we will continue expanding the types of tests available.
 
 - 01. [`Plan:` Chewing strategies for Large DataSets](../plans/chew-large-datasets)
 - 02. [`Plan:` Data Transfer of Random DataSets (Bitswap/GraphSync)](../plans/data-transfer-datasets-random)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
-# TestGround Roadmap
+# Testground Roadmap
 
-## **DISCLAIMER:** This Roadmap is still very much WIP. For a `"State of TestGround Update"` and `"Functional Roadmap"`, consult [`State of TestGround - Mid Q4 2019 (Team Only)`](https://docs.google.com/document/d/1lpifz6CSEYhas1a3ZpgCcDWAFl9Ysmr7o_JH0n8Vny0/edit#heading=h.8djx5icip69b). The primary milestone for the [`TestGround MVP is to Unblock go-ipfs 0.5.0`](https://github.com/ipfs/testground/issues/196)
+## **DISCLAIMER:** This Roadmap is still very much WIP. For a `"State of Testground Update"` and `"Functional Roadmap"`, consult [`State of Testground - Mid Q4 2019 (Team Only)`](https://docs.google.com/document/d/1lpifz6CSEYhas1a3ZpgCcDWAFl9Ysmr7o_JH0n8Vny0/edit#heading=h.8djx5icip69b). The primary milestone for the [`Testground MVP is to Unblock go-ipfs 0.5.0`](https://github.com/ipfs/testground/issues/196)
 
 # Q4 2019
 
@@ -15,12 +15,12 @@
 
 We have a format to spec out Test Plans and we've spec'ed out at least 10 Test Plans. These 10 Test Plans should directly contribute to increase the degree of confidence when shipping a go-ipfs Release 
 
-#### TestGround can levarage the Cloud to run its tests
+#### Testground can levarage the Cloud to run its tests
 
-- TestGround can run on Cloud Infrastructure as well as in local envinronment
+- Testground can run on Cloud Infrastructure as well as in local envinronment
 - A dashboard exists to visualize the result of the tests
 
-#### TestGround can simulate network conditions
+#### Testground can simulate network conditions
 
 For example: 
 - bottlenecks (networks with different bandwidth)
@@ -32,7 +32,7 @@ We started the quarter at 1 + 0.3 + 0.5
 
 ## OKRs
 
-Listed at [Q4 2019 IPFS OKRs - TestGround](https://docs.google.com/spreadsheets/d/1VeyiLvBdX_PrP394kU_lwkQZxfNwqMVX1f7K4ursSPM/edit#gid=96566767)
+Listed at [Q4 2019 IPFS OKRs - Testground](https://docs.google.com/spreadsheets/d/1VeyiLvBdX_PrP394kU_lwkQZxfNwqMVX1f7K4ursSPM/edit#gid=96566767)
 
 # Q1 2020
 

--- a/pkg/daemon/doc.go
+++ b/pkg/daemon/doc.go
@@ -1,5 +1,5 @@
-// Package daemon provides a type-safe client for the Testground server. TestGround uses a client-server architecture.
-// The Testground client talks to the TestGround daemon, which builds, and runs your test plans. The TestGround client
-// and daemon can run on the same system, or you can connect a Testground client to a remote TestGround daemon.
+// Package daemon provides a type-safe client for the Testground server. Testground uses a client-server architecture.
+// The Testground client talks to the Testground daemon, which builds, and runs your test plans. The Testground client
+// and daemon can run on the same system, or you can connect a Testground client to a remote Testground daemon.
 // Currently all commands to Testground, but the `daemon` command, are client-side commands.
 package daemon


### PR DESCRIPTION
This PR closes https://github.com/ipfs/testground/issues/212

@raulk do you think we need more docs on the `daemon`? I think this is just fine for now.