### PR TITLE
feat: add support for configuration with IPTB & directory sharding test with ext. daemon

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -292,7 +292,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
-golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
+golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/plans/chew-large-datasets/go.mod
+++ b/plans/chew-large-datasets/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ipfs/go-ipfs-api v0.0.2
 	github.com/ipfs/go-ipfs-config v0.0.11
 	github.com/ipfs/go-ipfs-files v0.0.4
-	github.com/ipfs/go-unixfs v0.2.1
 	github.com/ipfs/interface-go-ipfs-core v0.2.3
 	github.com/ipfs/testground/sdk/iptb v0.0.0-00010101000000-000000000000
 	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000

--- a/plans/chew-large-datasets/test/ipfs_add_defaults.go
+++ b/plans/chew-large-datasets/test/ipfs_add_defaults.go
@@ -21,14 +21,8 @@ func (t *IpfsAddDefaults) AcceptDirs() bool {
 	return false
 }
 
-func (t *IpfsAddDefaults) InstanceOptions() *utils.IpfsInstanceOptions {
-	return &utils.IpfsInstanceOptions{}
-}
-
-func (t *IpfsAddDefaults) DaemonOptions() *iptb.TestEnsembleSpec {
-	spec := iptb.NewTestEnsembleSpec()
-	spec.AddNodesDefaultConfig(iptb.NodeOpts{Initialize: true, Start: true}, "node")
-	return spec
+func (t *IpfsAddDefaults) AddRepoOptions() iptb.AddRepoOptions {
+	return nil
 }
 
 func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {

--- a/plans/chew-large-datasets/test/ipfs_add_dir_sharding.go
+++ b/plans/chew-large-datasets/test/ipfs_add_dir_sharding.go
@@ -53,7 +53,16 @@ func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("NOT IMPLEMENTED against the Daemon (IPTB)")
+		fmt.Println("Running against the Daemon (IPTB)")
+
+		err := cfg.ForEachPath(runenv, func(path string, isDir bool) (string, error) {
+			return cfg.IpfsDaemon.AddDir(path)
+		})
+
+		if err != nil {
+			runenv.Abort(err)
+			return
+		}
 	}
 
 	runenv.OK()

--- a/plans/chew-large-datasets/test/ipfs_add_dir_sharding.go
+++ b/plans/chew-large-datasets/test/ipfs_add_dir_sharding.go
@@ -21,17 +21,11 @@ func (t *IpfsAddDirSharding) AcceptDirs() bool {
 	return true
 }
 
-func (t *IpfsAddDirSharding) InstanceOptions() *utils.IpfsInstanceOptions {
-	return &utils.IpfsInstanceOptions{
-		RepoOpts: func(cfg *config.Config) error {
-			cfg.Experimental.ShardingEnabled = true
-			return nil
-		},
+func (t *IpfsAddDirSharding) AddRepoOptions() iptb.AddRepoOptions {
+	return func(cfg *config.Config) error {
+		cfg.Experimental.ShardingEnabled = true
+		return nil
 	}
-}
-
-func (t *IpfsAddDirSharding) DaemonOptions() *iptb.TestEnsembleSpec {
-	return nil
 }
 
 func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {

--- a/plans/chew-large-datasets/test/ipfs_add_trickle_dag.go
+++ b/plans/chew-large-datasets/test/ipfs_add_trickle_dag.go
@@ -23,14 +23,8 @@ func (t *IpfsAddTrickleDag) AcceptDirs() bool {
 	return false
 }
 
-func (t *IpfsAddTrickleDag) InstanceOptions() *utils.IpfsInstanceOptions {
-	return &utils.IpfsInstanceOptions{}
-}
-
-func (t *IpfsAddTrickleDag) DaemonOptions() *iptb.TestEnsembleSpec {
-	spec := iptb.NewTestEnsembleSpec()
-	spec.AddNodesDefaultConfig(iptb.NodeOpts{Initialize: true, Start: true}, "node")
-	return spec
+func (t *IpfsAddTrickleDag) AddRepoOptions() iptb.AddRepoOptions {
+	return nil
 }
 
 func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {

--- a/plans/chew-large-datasets/test/ipfs_file_store.go
+++ b/plans/chew-large-datasets/test/ipfs_file_store.go
@@ -22,17 +22,11 @@ func (t *IpfsFileStore) AcceptDirs() bool {
 	return true
 }
 
-func (t *IpfsFileStore) InstanceOptions() *utils.IpfsInstanceOptions {
-	return &utils.IpfsInstanceOptions{
-		RepoOpts: func(cfg *config.Config) error {
-			cfg.Experimental.FilestoreEnabled = true
-			return nil
-		},
+func (t *IpfsFileStore) AddRepoOptions() iptb.AddRepoOptions {
+	return func(cfg *config.Config) error {
+		cfg.Experimental.FilestoreEnabled = true
+		return nil
 	}
-}
-
-func (t *IpfsFileStore) DaemonOptions() *iptb.TestEnsembleSpec {
-	return nil
 }
 
 func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {

--- a/plans/chew-large-datasets/test/ipfs_mfs.go
+++ b/plans/chew-large-datasets/test/ipfs_mfs.go
@@ -20,11 +20,7 @@ func (t *IpfsMfs) AcceptDirs() bool {
 	return false
 }
 
-func (t *IpfsMfs) InstanceOptions() *utils.IpfsInstanceOptions {
-	return nil
-}
-
-func (t *IpfsMfs) DaemonOptions() *iptb.TestEnsembleSpec {
+func (t *IpfsMfs) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 

--- a/plans/chew-large-datasets/test/ipfs_mfs_dir_sharding.go
+++ b/plans/chew-large-datasets/test/ipfs_mfs_dir_sharding.go
@@ -20,11 +20,7 @@ func (t *IpfsMfsDirSharding) AcceptDirs() bool {
 	return true
 }
 
-func (t *IpfsMfsDirSharding) InstanceOptions() *utils.IpfsInstanceOptions {
-	return nil
-}
-
-func (t *IpfsMfsDirSharding) DaemonOptions() *iptb.TestEnsembleSpec {
+func (t *IpfsMfsDirSharding) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 

--- a/plans/chew-large-datasets/test/ipfs_url_store.go
+++ b/plans/chew-large-datasets/test/ipfs_url_store.go
@@ -21,17 +21,11 @@ func (t *IpfsUrlStore) AcceptDirs() bool {
 	return true
 }
 
-func (t *IpfsUrlStore) InstanceOptions() *utils.IpfsInstanceOptions {
-	return &utils.IpfsInstanceOptions{
-		RepoOpts: func(cfg *config.Config) error {
-			cfg.Experimental.UrlstoreEnabled = true
-			return nil
-		},
+func (t *IpfsUrlStore) AddRepoOptions() iptb.AddRepoOptions {
+	return func(cfg *config.Config) error {
+		cfg.Experimental.UrlstoreEnabled = true
+		return nil
 	}
-}
-
-func (t *IpfsUrlStore) DaemonOptions() *iptb.TestEnsembleSpec {
-	return nil
 }
 
 func (t *IpfsUrlStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {

--- a/plans/chew-large-datasets/utils/create-ipfs-instance.go
+++ b/plans/chew-large-datasets/utils/create-ipfs-instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipfs/go-ipfs/plugin/loader" // This package is needed so that all the preloaded plugins are loaded automatically
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	iCore "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipfs/testground/sdk/iptb"
 )
 
 /// ------ Setting up the IPFS Repo
@@ -37,10 +38,7 @@ func setupPlugins(externalPluginsPath string) error {
 	return nil
 }
 
-// AddRepoOptions allows to add custom options to repository settings.
-type AddRepoOptions func(*config.Config) error
-
-func createTempRepo(ctx context.Context, addFn AddRepoOptions) (string, error) {
+func createTempRepo(ctx context.Context, addFn iptb.AddRepoOptions) (string, error) {
 	repoPath, err := ioutil.TempDir("", "ipfs-shell")
 	if err != nil {
 		return "", fmt.Errorf("failed to get temp dir: %s", err)
@@ -99,7 +97,7 @@ func createNode(ctx context.Context, repoPath string) (iCore.CoreAPI, error) {
 
 // IpfsInstanceOptions represents the options to create an IPFS instance.
 type IpfsInstanceOptions struct {
-	RepoOpts AddRepoOptions
+	AddRepoOptions func(*config.Config) error
 }
 
 // CreateIpfsInstance spawns a node to be used just for this run (i.e. creates a tmp repo)
@@ -109,7 +107,7 @@ func CreateIpfsInstance(ctx context.Context, opts *IpfsInstanceOptions) (iCore.C
 	}
 
 	// Create a Temporary Repo
-	repoPath, err := createTempRepo(ctx, opts.RepoOpts)
+	repoPath, err := createTempRepo(ctx, opts.AddRepoOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp repo: %s", err)
 	}

--- a/plans/chew-large-datasets/utils/testcase.go
+++ b/plans/chew-large-datasets/utils/testcase.go
@@ -17,13 +17,9 @@ type TestCase interface {
 	// AcceptDirs indicates if this test will accept directories.
 	AcceptDirs() bool
 
-	// InstanceOptions returns the options needed to build a runtime instance
-	// of IPFS through the Core API.
-	InstanceOptions() *IpfsInstanceOptions
-
-	// DaemonOptions returns the options (ensemble) needed to build a daemon instance
-	// of IPFS through IPTB.
-	DaemonOptions() *iptb.TestEnsembleSpec
+	// AddRepoOptions returns a function that modifies a repository
+	// configuration to satisfy the test needs.
+	AddRepoOptions() iptb.AddRepoOptions
 
 	// Execute executes the test case with the given options.
 	Execute(ctx context.Context, runenv *runtime.RunEnv, opts *TestCaseOptions)

--- a/sdk/iptb/spec.go
+++ b/sdk/iptb/spec.go
@@ -7,40 +7,36 @@ import (
 )
 
 type TestEnsembleSpec struct {
-	tags map[string]*testNodeSpec
+	tags map[string]NodeOpts
 }
+
+type AddRepoOptions func(*config.Config) error
 
 type NodeOpts struct {
 	// Initialize tells us to initialize the newly created IPFS nodes (ipfs init).
 	Initialize bool
 	// Start tells us to start the newly created IPFS nodes as daemons.
 	Start bool
-}
-
-type testNodeSpec struct {
-	config *config.Config
-	opts   NodeOpts
+	// AddRepoOptions is a function that modifies the configuration of a repository.
+	AddRepoOptions AddRepoOptions
 }
 
 // NewTestEnsembleSpec creates a blank specification for a test ensemble.
 func NewTestEnsembleSpec() *TestEnsembleSpec {
 	return &TestEnsembleSpec{
-		tags: make(map[string]*testNodeSpec),
+		tags: make(map[string]NodeOpts),
 	}
 }
 
 // AddNodesDefaultConfig adds as many nodes to the ensemble as tags provided, making sure that tags are unique.
-//
-// All nodes will use the default IPFS configuration.
-//
-// TODO: this method will be refactored once we add first-class support for configs;
-//  configs may be provided via Options.
+// By default, all nodes will use the default IPFS configuration, but you can pass a AddOptions function on the
+// Node Options to replace some of the values.
 func (tes *TestEnsembleSpec) AddNodesDefaultConfig(opts NodeOpts, tags ...string) {
 	for _, tag := range tags {
 		if _, ok := tes.tags[tag]; ok {
 			panic(fmt.Sprintf("tag %s already exists in the test ensemble", tag))
 		}
-		tn := &testNodeSpec{opts: opts}
-		tes.tags[tag] = tn
+
+		tes.tags[tag] = opts
 	}
 }


### PR DESCRIPTION
This adds support for custom daemon configuration on IPTB (daemon) tests through a function that modifies the current configuration. I decided to use a function to modify the configuration instead of the configuration itself for some reasons:

1. It's what `CreateIpfsInstance` already does.
2. It easily allows to update the configuration of the IPTB-generated daemon with the command `ipfs config replace`.

Also, this enabled me to add one more test: dir sharding with the daemon! And the CIDs match!