### PR TITLE
feat: default runner builder on the manifest

### DIFF
--- a/manifests/chew-large-datasets.toml
+++ b/manifests/chew-large-datasets.toml
@@ -3,6 +3,10 @@ name = "chew-large-datasets"
 # hashicorp/go-getter URLs, so in the future we can support fetching test plans from GitHub.
 source_path = "file:${TESTGROUND_SRCDIR}/plans/chew-large-datasets"
 
+[defaults]
+builder = "docker:go"
+runner = "local:docker"
+
 [build_strategies."docker:go"]
 enabled = true
 go_version = "1.13"

--- a/pkg/api/definitions.go
+++ b/pkg/api/definitions.go
@@ -17,6 +17,14 @@ type TestPlanDefinition struct {
 	BuildStrategies map[string]config.ConfigMap `toml:"build_strategies"`
 	RunStrategies   map[string]config.ConfigMap `toml:"run_strategies"`
 	TestCases       []*TestCase                 `toml:"testcases"`
+	Defaults        TestPlanDefaults
+}
+
+// TestPlanDefaults represents the builder and runner defaults for
+// a certain test case.
+type TestPlanDefaults struct {
+	Builder string
+	Runner  string
 }
 
 // TestCase represents a configuration for a test case known by the system.
@@ -84,6 +92,14 @@ func (tp *TestPlanDefinition) Describe(w io.Writer) {
 		return res
 	}()
 	p(w, "It can be run with strategies: %v.", rs)
+
+	if tp.Defaults.Builder != "" {
+		p(w, "By default it builds with: %v", tp.Defaults.Builder)
+	}
+
+	if tp.Defaults.Runner != "" {
+		p(w, "By default it runs with: %v", tp.Defaults.Runner)
+	}
 
 	p(w, "It has %d test cases.", len(tp.TestCases))
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -148,6 +148,10 @@ func (e *Engine) DoBuild(testplan string, builder string, input *api.BuildInput,
 		return nil, fmt.Errorf("unknown test plan: %s", testplan)
 	}
 
+	if builder == "" {
+		builder = plan.Defaults.Builder
+	}
+
 	// Find the builder.
 	bm, ok := e.builders[builder]
 	if !ok {
@@ -206,6 +210,10 @@ func (e *Engine) DoRun(testplan string, testcase string, runner string, input *a
 	seq, tcase, ok := plan.TestCaseByName(testcase)
 	if !ok {
 		return nil, fmt.Errorf("unrecognized test case %s in test plan %s", testcase, testplan)
+	}
+
+	if runner == "" {
+		runner = plan.Defaults.Runner
 	}
 
 	// Get the runner.


### PR DESCRIPTION
Closes #124.

Adds support for a default runner and builder on the manifest.