### PR TITLE
Add metrics to Chew Datasets and use runenv.Message

### DIFF
--- a/plans/chew-datasets/go.mod
+++ b/plans/chew-datasets/go.mod
@@ -1,4 +1,4 @@
-module github.com/ipfs/testground/plans/chew-large-datasets
+module github.com/ipfs/testground/plans/chew-datasets
 
 go 1.13
 

--- a/plans/chew-datasets/main.go
+++ b/plans/chew-datasets/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ipfs/testground/plans/chew-large-datasets/test"
-	"github.com/ipfs/testground/plans/chew-large-datasets/utils"
+	"github.com/ipfs/testground/plans/chew-datasets/test"
+	"github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
 	"github.com/ipfs/testground/sdk/runtime"
 )

--- a/plans/chew-datasets/test/ipfs_add_defaults.go
+++ b/plans/chew-datasets/test/ipfs_add_defaults.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -28,7 +27,7 @@ func (t *IpfsAddDefaults) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
+		runenv.Message("Running against the Core API")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			unixfsFile, err := utils.ConvertToUnixfs(path, isDir)
@@ -53,7 +52,7 @@ func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, c
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
+		runenv.Message("Running against the Daemon (IPTB)")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (cid string, err error) {
 			file, err := os.Open(path)

--- a/plans/chew-datasets/test/ipfs_add_dir_sharding.go
+++ b/plans/chew-datasets/test/ipfs_add_dir_sharding.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	config "github.com/ipfs/go-ipfs-config"
@@ -31,7 +30,7 @@ func (t *IpfsAddDirSharding) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
+		runenv.Message("Running against the Core API")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			unixfsFile, err := utils.ConvertToUnixfs(path, isDir)
@@ -56,7 +55,7 @@ func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
+		runenv.Message("Running against the Daemon (IPTB)")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			tstarted := time.Now()
@@ -73,4 +72,3 @@ func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 
 	runenv.OK()
 }
-

--- a/plans/chew-datasets/test/ipfs_add_trickle_dag.go
+++ b/plans/chew-datasets/test/ipfs_add_trickle_dag.go
@@ -30,7 +30,7 @@ func (t *IpfsAddTrickleDag) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
+		runenv.Message("Running against the Core API")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			unixfsFile, err := utils.ConvertToUnixfs(path, isDir)
@@ -60,7 +60,7 @@ func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv,
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
+		runenv.Message("Running against the Daemon (IPTB)")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (cid string, err error) {
 			if isDir {

--- a/plans/chew-datasets/test/ipfs_file_store.go
+++ b/plans/chew-datasets/test/ipfs_file_store.go
@@ -6,7 +6,7 @@ import (
 
 	config "github.com/ipfs/go-ipfs-config"
 	coreopts "github.com/ipfs/interface-go-ipfs-core/options"
-	utils "github.com/ipfs/testground/plans/chew-large-datasets/utils"
+	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
 	"github.com/ipfs/testground/sdk/runtime"
 )
@@ -33,7 +33,7 @@ func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg
 	if cfg.IpfsInstance != nil {
 		fmt.Println("Running against the Core API")
 
-		err := cfg.ForEachPath(runenv, func(path string, isDir bool) (string, error) {
+		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			unixfsFile, err := utils.ConvertToUnixfs(path, isDir)
 			if err != nil {
 				return "", err

--- a/plans/chew-datasets/test/ipfs_file_store.go
+++ b/plans/chew-datasets/test/ipfs_file_store.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	config "github.com/ipfs/go-ipfs-config"
 	coreopts "github.com/ipfs/interface-go-ipfs-core/options"
@@ -31,7 +30,7 @@ func (t *IpfsFileStore) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
+		runenv.Message("Running against the Core API")
 
 		err := cfg.ForEachPath(runenv, func(path string, size int64, isDir bool) (string, error) {
 			unixfsFile, err := utils.ConvertToUnixfs(path, isDir)
@@ -54,12 +53,12 @@ func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg
 		}
 
 		// TODO: Act II and Act III
-		fmt.Println("Test incomplete")
+		runenv.Message("Test incomplete")
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
-		fmt.Println("Not implemented yet")
+		runenv.Message("Running against the Daemon (IPTB)")
+		runenv.Message("Not implemented yet")
 	}
 
 	runenv.OK()

--- a/plans/chew-datasets/test/ipfs_mfs.go
+++ b/plans/chew-datasets/test/ipfs_mfs.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
@@ -26,13 +25,13 @@ func (t *IpfsMfs) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsMfs) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Core API")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Daemon (IPTB)")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	runenv.OK()

--- a/plans/chew-datasets/test/ipfs_mfs.go
+++ b/plans/chew-datasets/test/ipfs_mfs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	utils "github.com/ipfs/testground/plans/chew-large-datasets/utils"
+	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
 	"github.com/ipfs/testground/sdk/runtime"
 )

--- a/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
+++ b/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	utils "github.com/ipfs/testground/plans/chew-large-datasets/utils"
+	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
 	"github.com/ipfs/testground/sdk/runtime"
 )

--- a/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
+++ b/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
@@ -26,13 +25,13 @@ func (t *IpfsMfsDirSharding) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsMfsDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Core API")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Daemon (IPTB)")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	runenv.OK()

--- a/plans/chew-datasets/test/ipfs_url_store.go
+++ b/plans/chew-datasets/test/ipfs_url_store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	config "github.com/ipfs/go-ipfs-config"
-	utils "github.com/ipfs/testground/plans/chew-large-datasets/utils"
+	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
 	"github.com/ipfs/testground/sdk/runtime"
 )

--- a/plans/chew-datasets/test/ipfs_url_store.go
+++ b/plans/chew-datasets/test/ipfs_url_store.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	config "github.com/ipfs/go-ipfs-config"
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
@@ -30,13 +29,13 @@ func (t *IpfsUrlStore) AddRepoOptions() iptb.AddRepoOptions {
 
 func (t *IpfsUrlStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
 	if cfg.IpfsInstance != nil {
-		fmt.Println("Running against the Core API")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Core API")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	if cfg.IpfsDaemon != nil {
-		fmt.Println("Running against the Daemon (IPTB)")
-		fmt.Println("Not Implemented Yet")
+		runenv.Message("Running against the Daemon (IPTB)")
+		runenv.Message("Not Implemented Yet")
 	}
 
 	runenv.OK()

--- a/plans/chew-datasets/utils/metrics.go
+++ b/plans/chew-datasets/utils/metrics.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"strconv"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+func MakeTimeToAddMetric(size int64, method string) *runtime.MetricDefinition {
+	return &runtime.MetricDefinition{
+		Name:           "time_to_add_" + method + "_" + strconv.FormatInt(size, 10),
+		Unit:           "ms",
+		ImprovementDir: -1,
+	}
+}

--- a/plans/chew-datasets/utils/testconfig.go
+++ b/plans/chew-datasets/utils/testconfig.go
@@ -39,7 +39,7 @@ func GetTestConfig(runenv *runtime.RunEnv, acceptFiles bool, acceptDirs bool) (c
 				return nil, err
 			}
 
-			fmt.Printf("%s: %s file created\n", file, humanize.Bytes(n))
+			runenv.Message("%s: %s file created", file, humanize.Bytes(n))
 
 			cfg = append(cfg, &TestDir{
 				Path: file,
@@ -72,7 +72,7 @@ func GetTestConfig(runenv *runtime.RunEnv, acceptFiles bool, acceptDirs bool) (c
 				return nil, err
 			}
 
-			fmt.Printf("%s: %s directory created\n", humanize.Bytes(n), path)
+			runenv.Message("%s: %s directory created", humanize.Bytes(n), path)
 
 			cfg = append(cfg, &TestDir{
 				Path:  path,
@@ -103,7 +103,7 @@ func (tc TestConfig) ForEachPath(runenv *runtime.RunEnv, fn OsTestFunction) erro
 				return fmt.Errorf("%s: failed to add %s", cfg.Path, err)
 			}
 
-			fmt.Printf("%s: %s added\n", cfg.Path, cid)
+			runenv.Message("%s: %s added", cfg.Path, cid)
 			return nil
 		}()
 

--- a/plans/chew-datasets/utils/testconfig.go
+++ b/plans/chew-datasets/utils/testconfig.go
@@ -85,7 +85,7 @@ func GetTestConfig(runenv *runtime.RunEnv, acceptFiles bool, acceptDirs bool) (c
 	return cfg, nil
 }
 
-type OsTestFunction func(path string, isDir bool) (string, error)
+type OsTestFunction func(path string, size int64, isDir bool) (string, error)
 
 func (tc TestConfig) ForEachPath(runenv *runtime.RunEnv, fn OsTestFunction) error {
 	for _, cfg := range tc {
@@ -94,9 +94,9 @@ func (tc TestConfig) ForEachPath(runenv *runtime.RunEnv, fn OsTestFunction) erro
 			var err error
 
 			if cfg.Depth == 0 {
-				cid, err = fn(cfg.Path, false)
+				cid, err = fn(cfg.Path, cfg.Size, false)
 			} else {
-				cid, err = fn(cfg.Path, true)
+				cid, err = fn(cfg.Path, cfg.Size, true)
 			}
 
 			if err != nil {


### PR DESCRIPTION
What the title says!

- Adds metrics for each added file on chew datasets
- Uses runenv.Message instead of fmt.Println/Printf