### PR TITLE
Avoid segfault during build time errors

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -197,6 +197,9 @@ func (e *Engine) DoBuild(testplan string, builder string, input *api.BuildInput,
 	input.EnvConfig = *e.envcfg
 
 	res, err := bm.Build(input, output)
+	if err != nil {
+		return nil, err
+	}
 	res.BuilderID = bm.ID()
 	return res, err
 }


### PR DESCRIPTION
When there's an error condition, the engine is segfaulting instead of
displaying the error.

To reproduce, force an error by deleting plan/dht/go.mod, and then
build:

```
Dec 12 03:07:34.544927  INFO    listen and serve        {"addr": "[::]:54353"}
Dec 12 03:07:34.551196  DEBUG   handle request  {"ruid": "42aaa4e5", "command": "build"}
Dec 12 03:07:34.620603  DEBUG   request handled {"ruid": "42aaa4e5", "command": "build"}
2019/12/11 19:07:34 http: panic serving [::1]:54354: runtime error: invalid memory address or nil pointer dereference
goroutine 36 [running]:
net/http.(*conn).serve.func1(0xc0000dc3c0)
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:1767 +0x139
panic(0x1ab4660, 0x253ab00)
        /usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/ipfs/testground/pkg/engine.(*Engine).DoBuild(0xc0000461c0, 0xc00023e06d, 0x3, 0xc00023e0a0, 0x9, 0xc0001b43c0, 0x1e50f60, 0xc000264fa0, 0x2, 0x2, ...)
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/engine/engine.go:200 +0x5bb
github.com/ipfs/testground/pkg/server.(*Server).buildHandler(0xc0000ce130, 0x1e65260, 0xc000196000, 0xc00019e100, 0xc0001a0000)
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/server/build.go:39 +0x61f
github.com/ipfs/testground/pkg/server.loggingHandler.func1(0x1e65260, 0xc000196000, 0xc00019e100)
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/server/server.go:62 +0xe7
net/http.HandlerFunc.ServeHTTP(0xc0000b7700, 0x1e65260, 0xc000196000, 0xc00019e100)
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:2007 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00007e180, 0x1e65260, 0xc000196000, 0xc00014e000)
        /Users/jim/go/pkg/mod/github.com/gorilla/mux@v1.7.3/mux.go:212 +0xe2
net/http.serverHandler.ServeHTTP(0xc00001c1c0, 0x1e65260, 0xc000196000, 0xc00014e000)
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0000dc3c0, 0x1e6a620, 0xc00058a100)
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:2927 +0x38e
fatal error from daemon: Post http://[::]:54353/build: EOF
```

With this fix, the error is visible again:

```
Dec 12 03:08:35.890551  INFO    listen and serve        {"addr": "[::]:55151"}
Dec 12 03:08:35.892066  DEBUG   handle request  {"ruid": "7971a03e", "command": "build"}
Dec 12 03:08:35.940963  WARN    engine build error: unable to add replace directives to go.mod; exit status 1   {"ruid": "7971a03e"}
github.com/ipfs/testground/pkg/server.errf
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/server/errf.go:10
github.com/ipfs/testground/pkg/server.(*Server).buildHandler
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/server/build.go:41
github.com/ipfs/testground/pkg/server.loggingHandler.func1
        /Users/jim/backblend-jpimac/clients/protocol-labs/test-infra/testground/pkg/server/server.go:62
net/http.HandlerFunc.ServeHTTP
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:2007
github.com/gorilla/mux.(*Router).ServeHTTP
        /Users/jim/go/pkg/mod/github.com/gorilla/mux@v1.7.3/mux.go:212
net/http.serverHandler.ServeHTTP
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:2802
net/http.(*conn).serve
        /usr/local/Cellar/go/1.13.4/libexec/src/net/http/server.go:1890
Dec 12 03:08:35.941133  DEBUG   request handled {"ruid": "7971a03e", "command": "build"}
engine build error: unable to add replace directives to go.mod; exit status 1
```

Now I can see that I need to look at go.mod...