### PR TITLE
aws eks terraform playbooks

### DIFF
--- a/infra/k8s/README-aws.md
+++ b/infra/k8s/README-aws.md
@@ -50,4 +50,24 @@ terraform plan
 terraform apply
 ```
 
-7. Use `terraform destroy` to remove the cluster from AWS when you are finished working on it.
+7. Update your local .kube config and context
+
+```
+aws eks update-kubeconfig --name tony
+```
+
+8. Export Terraform outputs
+
+```
+terraform output config-map-aws-auth > outputs/config-map-aws-auth.yaml
+```
+
+9. Apply config to Kubernetes cluster
+
+```
+kubectl apply -f ./outputs/config-map-aws-auth.yaml
+```
+
+## Teardown
+
+Use `terraform destroy` to remove the cluster from AWS when you are finished working on it.

--- a/infra/k8s/README-aws.md
+++ b/infra/k8s/README-aws.md
@@ -1,0 +1,53 @@
+# Setting up a Kubernetes cluster on AWS for Testground
+
+In this directory, you will find:
+
+```
+» tree
+.
+├── README-aws.md
+└── aws
+    └── terraform          # Playbooks used to setup AWS EKS cluster for Testground - EC2 instances, security groups, networks, etc.
+```
+
+## Requirements
+
+- 1. [Terraform](https://www.terraform.io/).
+
+## Set up infrastructure with Terraform
+
+1. [Configure your AWS credentials](https://docs.aws.amazon.com/cli/)
+
+2. Pick a cluster name. Cluster names must be unique within the same AWS account.
+
+```
+export CLUSTER_NAME=demo
+```
+
+3. Configure the Terraform backend
+
+- Copy `backends/example-backend.tf` to `backends/$CLUSTER_NAME.tf`
+- Update `key` value in `backends/$CLUSTER_NAME.tf`
+
+4. Initialise the Terraform backend
+
+```
+terraform init -backend-config=backends/$CLUSTER_NAME.tf
+```
+
+5. Configure your cluster
+
+- Copy `terraform.tfvars-example` to `terraform.tfvars`
+- Update vars
+
+6. Plan and apply a new cluster with Terraform
+
+```
+terraform plan
+```
+
+```
+terraform apply
+```
+
+7. Use `terraform destroy` to remove the cluster from AWS when you are finished working on it.

--- a/infra/k8s/README-aws.md
+++ b/infra/k8s/README-aws.md
@@ -56,9 +56,10 @@ terraform apply
 aws eks update-kubeconfig --name $CLUSTER_NAME
 ```
 
-8. Export Terraform outputs
+8. Edit outputs.tf, add admin users to the config (whoever is going to operate the AWS EKS cluster), and export Terraform outputs
 
 ```
+vim config-map-aws-auth
 terraform output config-map-aws-auth > outputs/config-map-aws-auth.yaml
 ```
 

--- a/infra/k8s/README-aws.md
+++ b/infra/k8s/README-aws.md
@@ -53,7 +53,7 @@ terraform apply
 7. Update your local .kube config and context
 
 ```
-aws eks update-kubeconfig --name tony
+aws eks update-kubeconfig --name $CLUSTER_NAME
 ```
 
 8. Export Terraform outputs

--- a/infra/k8s/aws/terraform/.gitignore
+++ b/infra/k8s/aws/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+outputs/config-map-aws-auth.yaml

--- a/infra/k8s/aws/terraform/backend.tf
+++ b/infra/k8s/aws/terraform/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "s3" {
+  }
+}

--- a/infra/k8s/aws/terraform/backends/example-backend.tf
+++ b/infra/k8s/aws/terraform/backends/example-backend.tf
@@ -1,0 +1,4 @@
+bucket = "terraform-backend-testground"
+key    = "$CLUSTER_NAME.tfstate"
+region = "eu-central-1"
+

--- a/infra/k8s/aws/terraform/backends/example-backend.tf
+++ b/infra/k8s/aws/terraform/backends/example-backend.tf
@@ -1,4 +1,3 @@
 bucket = "terraform-backend-testground"
-key    = "$CLUSTER_NAME.tfstate"
+key    = "<cluster_name>.tfstate"
 region = "eu-central-1"
-

--- a/infra/k8s/aws/terraform/eks-cluster.tf
+++ b/infra/k8s/aws/terraform/eks-cluster.tf
@@ -1,0 +1,79 @@
+# EKS Cluster Resources
+#  * IAM Role to allow EKS service to manage other AWS services
+#  * EC2 Security Group to allow networking traffic with EKS cluster
+#  * EKS Cluster
+
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster-name}-cluster"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_security_group" "cluster" {
+  name        = "${var.cluster-name}-cluster"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = aws_vpc.vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.default_tags,
+    {
+      "Name" = var.cluster-name
+    },
+  )
+}
+
+resource "aws_security_group_rule" "cluster-ingress-node-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.cluster.id
+  source_security_group_id = aws_security_group.node-public.id
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_eks_cluster" "cluster" {
+  name     = var.cluster-name
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    security_group_ids = [aws_security_group.cluster.id]
+    subnet_ids         = aws_subnet.subnet.*.id
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.cluster-AmazonEKSServicePolicy,
+  ]
+}

--- a/infra/k8s/aws/terraform/eks-worker-nodes.tf
+++ b/infra/k8s/aws/terraform/eks-worker-nodes.tf
@@ -1,0 +1,260 @@
+# EKS Worker Nodes Resources
+#  * IAM roles:
+#     - allowing Kubernetes actions to access other AWS services
+#     - allowing to change autoscaling groups. Used by cluster-autoscaler
+#  * EC2 Security Group to allow networking traffic
+#  * Data source to fetch latest EKS worker AMI
+#  * AutoScaling Launch Configuration to configure worker instances
+#  * AutoScaling Group to launch worker instances
+
+resource "aws_iam_role" "node-public" {
+  name = "${var.cluster-name}-node"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+
+}
+
+resource "aws_iam_role_policy_attachment" "node-public-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node-public.name
+}
+
+resource "aws_iam_role_policy_attachment" "node-public-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node-public.name
+}
+
+resource "aws_iam_role_policy_attachment" "node-public-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node-public.name
+}
+
+resource "aws_iam_instance_profile" "node-public" {
+  name = var.cluster-name
+  role = aws_iam_role.node-public.name
+}
+
+## Autoscaling IAM
+
+data "aws_iam_policy_document" "worker_autoscaling" {
+  statement {
+    sid    = "eksWorkerAutoscalingAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "eksWorkerAutoscalingOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster-name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "worker_autoscaling" {
+  name_prefix = "eks-worker-autoscaling-${var.cluster-name}"
+  description = "EKS worker node autoscaling policy for cluster ${var.cluster-name}"
+  policy      = data.aws_iam_policy_document.worker_autoscaling.json
+}
+
+resource "aws_iam_role_policy_attachment" "node-public_autoscaling" {
+  policy_arn = aws_iam_policy.worker_autoscaling.arn
+  role       = aws_iam_role.node-public.name
+}
+
+# Security groups
+resource "aws_security_group" "node-public" {
+  name        = "${var.cluster-name}-node"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = aws_vpc.vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.default_tags,
+    {
+      "Name"                                      = "${var.cluster-name}-node"
+      "kubernetes.io/cluster/${var.cluster-name}" = "owned"
+    },
+  )
+}
+
+resource "aws_security_group_rule" "node-public-ingress-self" {
+  description              = "Allow node to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.node-public.id
+  source_security_group_id = aws_security_group.node-public.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-public-ingress-cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node-public.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-public-ingress-cluster-443" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane on 443. Required by metrics-server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.node-public.id
+  source_security_group_id = aws_security_group.cluster.id
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "node-public-ingress-services" {
+  description       = "Allow worker Kubelets and pods to receive communication from the Internet to ports 30000-32767"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "tcp"
+  security_group_id = aws_security_group.node-public.id
+  type              = "ingress"
+
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "node-public-ssh" {
+  description       = "Allow SSH on worker Kubelets"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.node-public.id
+  type              = "ingress"
+
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+## Worker node definitions
+data "aws_ami" "eks_node_ami" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-1.14-v20190927"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon EKS AMI Account ID
+}
+
+# The EKS AMI provides a bootstrap script to setup and connect your worker nodes.
+# More info: https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh
+locals {
+  eks_node_userdata = <<USERDATA
+#!/bin/bash -xe
+set -o xtrace
+
+/etc/eks/bootstrap.sh \
+  --apiserver-endpoint '${aws_eks_cluster.cluster.endpoint}' \
+  --b64-cluster-ca '${aws_eks_cluster.cluster.certificate_authority[0].data}' \
+  --use-max-pods true \
+  '${var.cluster-name}'
+USERDATA
+}
+
+resource "aws_launch_configuration" "eks_node_launch_configuration" {
+  iam_instance_profile        = aws_iam_instance_profile.node-public.name
+  image_id                    = data.aws_ami.eks_node_ami.id
+  instance_type               = var.worker-instance-type
+  name_prefix                 = "${var.cluster-name}-worker-node"
+  security_groups             = [aws_security_group.node-public.id]
+  user_data_base64            = base64encode(local.eks_node_userdata)
+  key_name                    = var.key-name
+  associate_public_ip_address = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "eks_node_autoscaling_group_v2" {
+  # NOTE: You might need to update the desired_capacity. We do have the cluster-autoscaler
+  # running within k8s. This component adjusts the desired_capacity automatically based on resource usage.
+  # Make sure that you adjust the desired_ capacity to whatever is currently defined in the ASG. (hint: use terraform plan)
+  desired_capacity = 1
+
+  launch_configuration = aws_launch_configuration.eks_node_launch_configuration.id
+  max_size             = 20
+  min_size             = 1
+  name                 = "${var.cluster-name}-worker-node"
+  vpc_zone_identifier  = aws_subnet.subnet.*.id
+
+  tag {
+    key                 = "Name"
+    value               = "${var.cluster-name}-worker-node"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/enabled"
+    value               = "true"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "Team"
+    value               = "testground"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "test"
+    propagate_at_launch = true
+  }
+}

--- a/infra/k8s/aws/terraform/key.tf
+++ b/infra/k8s/aws/terraform/key.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "key_pair" {
+  key_name   = var.key-name
+  public_key = var.public-key
+}

--- a/infra/k8s/aws/terraform/outputs.tf
+++ b/infra/k8s/aws/terraform/outputs.tf
@@ -15,28 +15,8 @@ data:
         - system:bootstrappers
         - system:nodes
   mapUsers: |
-    - userarn: arn:aws:iam::909427826938:user/anton
-      username: anton
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::909427826938:user/daviddias
-      username: anton
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::909427826938:user/dirkmc
-      username: anton
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::909427826938:user/jim
-      username: anton
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::909427826938:user/raulk
-      username: anton
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::909427826938:user/Stebalien
-      username: anton
+    - userarn: arn:aws:iam::909427826938:user/YOUR_USERNAME
+      username: $YOUR_USERNAME
       groups:
         - system:masters
 

--- a/infra/k8s/aws/terraform/outputs.tf
+++ b/infra/k8s/aws/terraform/outputs.tf
@@ -15,8 +15,8 @@ data:
         - system:bootstrappers
         - system:nodes
   mapUsers: |
-    - userarn: arn:aws:iam::909427826938:user/YOUR_USERNAME
-      username: $YOUR_USERNAME
+    - userarn: <user_arn, e.g. arn:aws:iam::909427826938:user/YOUR_USERNAME, click on your user in https://console.aws.amazon.com/iam/home?#/users, and copy it>
+      username: <your_aws_username>
       groups:
         - system:masters
 
@@ -39,4 +39,3 @@ output "kubeca" {
 output "kubehost" {
   value = local.kubehost
 }
-

--- a/infra/k8s/aws/terraform/outputs.tf
+++ b/infra/k8s/aws/terraform/outputs.tf
@@ -1,0 +1,62 @@
+locals {
+  config-map-aws-auth = <<CONFIGMAPAWSAUTH
+
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - rolearn: ${aws_iam_role.node-public.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+  mapUsers: |
+    - userarn: arn:aws:iam::909427826938:user/anton
+      username: anton
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::909427826938:user/daviddias
+      username: anton
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::909427826938:user/dirkmc
+      username: anton
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::909427826938:user/jim
+      username: anton
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::909427826938:user/raulk
+      username: anton
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::909427826938:user/Stebalien
+      username: anton
+      groups:
+        - system:masters
+
+
+CONFIGMAPAWSAUTH
+
+
+  kubeca   = aws_eks_cluster.cluster.certificate_authority[0].data
+  kubehost = aws_eks_cluster.cluster.endpoint
+}
+
+output "config-map-aws-auth" {
+  value = local.config-map-aws-auth
+}
+
+output "kubeca" {
+  value = local.kubeca
+}
+
+output "kubehost" {
+  value = local.kubehost
+}
+

--- a/infra/k8s/aws/terraform/providers.tf
+++ b/infra/k8s/aws/terraform/providers.tf
@@ -1,0 +1,22 @@
+#
+# Provider Configuration
+#
+
+provider "aws" {
+  region = var.cluster-region
+}
+
+# Using these data sources allows the configuration to be
+# generic for any region.
+data "aws_region" "current" {
+}
+
+data "aws_availability_zones" "available" {
+}
+
+# Not required: currently used in conjuction with using
+# icanhazip.com to determine local workstation external IP
+# to open EC2 Security Group access to the Kubernetes cluster.
+# See workstation-external-ip.tf for additional information.
+provider "http" {
+}

--- a/infra/k8s/aws/terraform/terraform.tfvars-example
+++ b/infra/k8s/aws/terraform/terraform.tfvars-example
@@ -1,4 +1,4 @@
-cluster-name   = "$CLUSTER_NAME"
+cluster-name   = "<cluster_name>"
 cluster-region = "eu-central-1"
-key-name       = "$YOUR_KEY_NAME"
-public-key     = "$PUBLIC_KEY"
+key-name       = "<key_name, doesn't need to match anything>"
+public-key     = "<copy your pubkey here>"

--- a/infra/k8s/aws/terraform/terraform.tfvars-example
+++ b/infra/k8s/aws/terraform/terraform.tfvars-example
@@ -1,0 +1,4 @@
+cluster-name   = "$CLUSTER_NAME"
+cluster-region = "eu-central-1"
+key-name       = "$YOUR_KEY_NAME"
+public-key     = "$PUBLIC_KEY"

--- a/infra/k8s/aws/terraform/variables.tf
+++ b/infra/k8s/aws/terraform/variables.tf
@@ -1,0 +1,32 @@
+variable "cluster-name" {
+  type = string
+}
+
+variable "cluster-region" {
+  type = string
+}
+
+variable "key-name" {
+  type = string
+}
+
+variable "public-key" {
+  type = string
+}
+
+variable "default_tags" {
+  type = map(string)
+
+  default = {
+    Environment = "test"
+    Team        = "testground"
+  }
+}
+
+# see /etc/eks/eni-max-pods.txt for max pods per instance type
+# m5.4xlarge - $0.768 per hour - 16 vCPU 64 GB RAM - max 234 pods per instance - ~270MB per pod
+# m5.2xlarge - $0.384 per hour - 8  vCPU 32 GB RAM - max 58 pods per instance - ~550MB per pod
+variable "worker-instance-type" {
+  type    = string
+  default = "m5.4xlarge"
+}

--- a/infra/k8s/aws/terraform/versions.tf
+++ b/infra/k8s/aws/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/infra/k8s/aws/terraform/vpc.tf
+++ b/infra/k8s/aws/terraform/vpc.tf
@@ -1,0 +1,58 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(
+    var.default_tags,
+    {
+      "Name"                                      = var.cluster-name
+      "kubernetes.io/cluster/${var.cluster-name}" = "shared"
+    },
+  )
+}
+
+resource "aws_subnet" "subnet" {
+  count = 2
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = "10.0.${64 * count.index}.0/18"
+  vpc_id            = aws_vpc.vpc.id
+
+  tags = merge(
+    var.default_tags,
+    {
+      "Name"                                      = var.cluster-name
+      "kubernetes.io/cluster/${var.cluster-name}" = "shared"
+    },
+  )
+}
+
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = merge(
+    var.default_tags,
+    {
+      "Name" = var.cluster-name
+    },
+  )
+}
+
+resource "aws_route_table" "rt" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.ig.id
+  }
+
+  tags = merge(var.default_tags)
+}
+
+resource "aws_route_table_association" "rta" {
+  count = 2
+
+  subnet_id      = aws_subnet.subnet[count.index].id
+  route_table_id = aws_route_table.rt.id
+}


### PR DESCRIPTION
This PR is adding Terraform playbook for creating an AWS EKS cluster.

We haven't decided which orchestrator or cloud we will use for the Testground MVP, but I think it is good to keep our options open and commit the playbooks / setups we are evaluating.