### PR TITLE
fix: remove local docker timeout

### DIFF
--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -237,7 +237,7 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 
 	if !cfg.Background {
 		output := NewConsoleOutput()
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		for _, id := range containers {
 			stream, err := cli.ContainerLogs(ctx, id, types.ContainerLogsOptions{


### PR DESCRIPTION
The tests themselves handle timeouts. This timeout was:

1. Too short.
2. Hiding timeout errors from containers themselves.

If we really need one, we can introduce a timeout here later. However, IMO, timeouts should be handled by the user (e.g., with an interrupt).