### PR TITLE
feat(console): don't decode stderr

### DIFF
--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -252,13 +252,15 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 				return nil, deleteContainers(cli, log, containers)
 			}
 
-			rpipe, wpipe := io.Pipe()
+			rstdout, wstdout := io.Pipe()
+			rstderr, wstderr := io.Pipe()
 			go func() {
-				_, err := stdcopy.StdCopy(wpipe, wpipe, stream)
-				_ = wpipe.CloseWithError(err)
+				_, err := stdcopy.StdCopy(wstdout, wstderr, stream)
+				_ = wstdout.CloseWithError(err)
+				_ = wstderr.CloseWithError(err)
 			}()
 
-            output.Manage(id[0:12], rpipe)
+			output.Manage(id[0:12], rstdout, rstderr)
 		}
 		return nil, output.Wait()
 	}

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -109,7 +109,7 @@ func (*LocalExecutableRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOu
 
 		cmd := exec.Command(input.ArtifactPath)
 		stdout, _ := cmd.StdoutPipe()
-		cmd.Stderr = cmd.Stdout // interleave stdout/stderr
+		stderr, _ := cmd.StderrPipe()
 		cmd.Env = env
 
 		if err := cmd.Start(); err != nil {
@@ -118,7 +118,7 @@ func (*LocalExecutableRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOu
 		}
 		commands = append(commands, cmd)
 
-		console.Manage(id, stdout)
+		console.Manage(id, stdout, stderr)
 	}
 	if err := console.Wait(); err != nil {
 		return nil, err


### PR DESCRIPTION
Panics and other logs go to stderr. We shouldn't try to decode stderr as json.