### PR TITLE
Sidecar: add method to set IP addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - GO111MODULE=on pushd .. && go get github.com/golangci/golangci-lint/cmd/golangci-lint && popd
         - golangci-lint run       # run a bunch of code checkers/linters in parallel
         - go build ./...          # build the project
+        - docker build -t ipfs/testground .
         - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./... # Run all the tests with the race detector enabled
         - go build .
       after_success:

--- a/cmd/itest/run_test.go
+++ b/cmd/itest/run_test.go
@@ -49,7 +49,7 @@ func TestIncompatibleRun(t *testing.T) {
 	}
 }
 
-func TestCompatibleRun(t *testing.T) {
+func TestCompatibleRunLocal(t *testing.T) {
 	err := runSingle(t,
 		"run",
 		"placebo/ok",
@@ -57,6 +57,21 @@ func TestCompatibleRun(t *testing.T) {
 		"exec:go",
 		"--runner",
 		"local:exec",
+	)
+
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestCompatibleRunDocker(t *testing.T) {
+	err := runSingle(t,
+		"run",
+		"placebo/ok",
+		"--builder",
+		"docker:go",
+		"--runner",
+		"local:docker",
 	)
 
 	if err != nil {

--- a/cmd/itest/sidecar_test.go
+++ b/cmd/itest/sidecar_test.go
@@ -1,0 +1,20 @@
+package cmd_test
+
+import (
+	"testing"
+)
+
+func TestSidecar(t *testing.T) {
+	err := runSingle(t,
+		"run",
+		"network/ping-pong",
+		"--builder",
+		"docker:go",
+		"--runner",
+		"local:docker",
+	)
+
+	if err != nil {
+		t.Fail()
+	}
+}

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -7,7 +7,7 @@ control and a data network.
 * Test instances communicate with the sync service, and _only_ the sync service,
   over the control network.
 
-The local runner will use your machines local network interfaces.
+The local runner will use your machine's local network interfaces. For now, this runner doesn't support traffic shaping.
 
 ## Control Network
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -1,0 +1,33 @@
+# Networking
+
+All testground runners _except_ for the local runner have two networks: a
+control and a data network.
+
+* Test instances communicate with each other over the data network.
+* Test instances communicate with the sync service, and _only_ the sync service,
+  over the control network.
+
+The local runner will use your machines local network interfaces.
+
+## Control Network
+
+The "control network" runs on 192.168.0.1/16 and should only be used to
+communicate with the sync service.
+
+After the sidecar is finished [initializing the
+network](https://github.com/ipfs/testground/blob/master/docs/SIDECAR.md#initialization),
+it should be impossible to use this network to communicate with other nodes.
+However, a good test plan should avoid listening on and/or announcing this
+network _anyways_ to ensure that it doesn't interfere with the test.
+
+## Data Network
+
+The "data network", used for all inter-instance communication, will be assigned
+a B block in the IP range 16.0.0.0 - 32.0.0.0. Given the B block X.Y.0.0,
+X.Y.0.1 is always the gateway and shouldn't be used by the test.
+
+The subnet used will be passed to the test instance via the runtime environment
+(as `TestSubnet`).
+
+You can change your IP address (within this range) at any time [using the
+sidecar](https://github.com/ipfs/testground/blob/master/docs/SIDECAR.md#ip-addresses).

--- a/docs/SIDECAR.md
+++ b/docs/SIDECAR.md
@@ -66,7 +66,7 @@ if err != nil {
 
 ### Configure: Create
 
-Once the network is ready, you'll need ot actually _configure_ your network.
+Once the network is ready, you'll need to actually _configure_ your network.
 
 ```go
 config := sync.NetworkConfig{

--- a/docs/SIDECAR.md
+++ b/docs/SIDECAR.md
@@ -1,0 +1,180 @@
+# Sidecar
+
+Before you read this, read the
+[networking](https://github.com/ipfs/testground/blob/master/docs/NETWORKING.md)
+documentation.
+
+In testground, a test instance can configure its own network (IP address,
+jitter, latency, bandwidth, etc.) by writing a `NetworkConfig` to the sync
+service, then waiting for the specified `State` to be set.
+
+## Worked Example
+
+### Imports
+
+For this example, you'll need the following packages:
+
+```go
+import (
+	"net"
+	"os"
+	"reflect"
+
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/ipfs/testground/sdk/sync"
+)
+```
+
+### Pre-Check
+
+First, check to make sure the sidecar is even available. At the moment, it's
+only available on docker-based runners. If it's not available, just skip any
+networking config code and proceed.
+
+```go
+// runenv is the test instances run environment (runtime.RunEnv).
+if !runenv.TestSidecar {
+    return
+}
+```
+
+### Initialization
+
+First, wait for the sidecar to initialize the network.
+
+```go
+if err := sync.WaitNetworkInitialized(ctx, runenv, watcher); err != nil {
+    runenv.Abort(err)
+    return
+}
+```
+
+If you don't want to customize the network (set IP addresses, latency, etc.),
+you can stop here.
+
+### Hostname
+
+The sidecar identifies test instances by their hostname.
+
+```go
+hostname, err := os.Hostname()
+if err != nil {
+    runenv.Abort(err)
+    return
+}
+```
+
+### Configure: Create
+
+Once the network is ready, you'll need ot actually _configure_ your network.
+
+```go
+config := sync.NetworkConfig{
+    // Control the "default" network. At the moment, this is the only network.
+    Network: "default",
+
+    // Enable this network. Setting this to false will disconnect this test
+    // instance from this network. You probably don't want to do that.
+    Enable:  true,
+}
+```
+
+#### Traffic Shaping
+
+To "shape" traffic, set the `Default` `LinkShape`. You can use this to set
+latency, bandwidth, jitter, etc.
+
+```go
+config.Default = sync.LinkShape{
+    Latency:   100 * time.Millisecond,
+    Bandwidth: 1 << 20, // 1Mib
+}
+```
+
+NOTE: This sets _egress_ (outbound) properties on the link. These settings must
+be symmetric (applied on both sides of the connection) to work properly (unless
+asymmetric bandwidth/latency/etc. is desired).
+
+NOTE: Per-subnet traffic shaping is a desired but unimplemented feature.
+The sidecar will reject configs with per-subnet rules set in
+`NetworkConfig.Rules`.
+
+#### IP Addresses
+
+If you don't specify an IPv4 address when configuring your network, your test
+instance will keep the default assignment. However, if desired, a test instance
+can change its IP address at any time.
+
+First, you'll need some kind of unique sequence number to ensure you don't pick
+conflicting addresses. If you don't already have some form of unique sequence
+number at this point in your tests, use the sync service to get one:
+
+```go
+seq, err := writer.Write(&sync.Subtree{
+    GroupKey:    "ip-allocation",
+    PayloadType: reflect.TypeOf(""),
+    KeyFunc: func(val interface{}) string {
+        return val.(string)
+    },
+}, hostname)
+if err != nil {
+    runenv.Abort(err)
+    return
+}
+```
+
+Once you have a sequence number, you can set your IP address from one of the
+available subnets:
+
+```go
+// copy the test subnet.
+config.IPv4 = &*runenv.TestSubnet
+// Use the sequence number to fill in the last two octets.
+//
+// NOTE: Be careful not to modify the IP from `runenv.TestSubnet`.
+// That could trigger undefined behavior.
+ipC := byte((seq >> 8) + 1)
+ipD := byte(seq)
+config.IPv4.IP = append(config.IPv4.IP[0:2:2], ipC, ipD)
+```
+
+NOTE: You cannot currently set an IPv6 address.
+
+### Configure: Apply
+
+Network configurations are applied as follows:
+
+1. The test instance sets a "state" that should be signaled when the new
+   configuration has been applied.
+
+```go
+config.State = "network-configured"
+```
+
+2. The test instance writes the new network configuration to the sync service.
+
+```go
+_, err = writer.Write(sync.NetworkSubtree(hostname), &config)
+if err != nil {
+    runenv.Abort(err)
+    return
+}
+```
+
+3. The test instance _waits_ on the specified "state" (barrier). Note: the
+   following example will wait for _all_ test instances to finish configuring
+   their networks.
+
+```go
+err = <-watcher.Barrier(ctx, config.State, int64(runenv.TestInstanceCount))
+if err != nil {
+    runenv.Abort(err)
+    return
+}
+```
+
+The sidecar follows the complementary steps:
+
+1. The sidecar reads the network configuration from the sync service.
+2. The sidecar applies the network configuration.
+3. The sidecar signals the configured "state".

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -275,3 +275,22 @@ ok := runenv.JSONParam("myparam", &v)
 fmt.Println(v)
 // map[key1:value1 key2:value2]
 ```
+
+### Networking & Sidecar
+
+Where supported (all runners except the local:go runner), the "sidecar" service
+is responsible for configuring the network for each test instance. At a
+_minimum_, you should wait for the network to be initialized before proceeding
+with your test.
+
+```go
+if err := sync.WaitNetworkInitialized(ctx context.Context, runenv, watcher); err != nil {
+    runtime.Abort(err)
+    return
+}
+```
+
+For more powerful network management (e.g., setting bandwidth limits and
+latencies), see the
+[sidecar](https://github.com/ipfs/testground/blob/master/docs/SIDECAR.md)
+documentation.

--- a/manifests/network.toml
+++ b/manifests/network.toml
@@ -1,0 +1,34 @@
+name = "network"
+# hashicorp/go-getter URLs, so in the future we can support fetching test plans
+# from GitHub.
+source_path = "file://${TESTGROUND_SRCDIR}/plans/network"
+
+[defaults]
+builder = "exec:go"
+runner = "local:exec"
+
+[build_strategies."docker:go"]
+enabled = true
+go_version = "1.13"
+module_path = "github.com/ipfs/testground/plans/network"
+exec_pkg = "."
+go_ipfs_version = "0.4.22"
+
+[build_strategies."exec:go"]
+enabled = true
+module_path = "github.com/ipfs/testground/plans/network"
+exec_pkg = "."
+
+[run_strategies."local:docker"]
+enabled = true
+
+[run_strategies."local:exec"]
+enabled = true
+
+[run_strategies."cluster:swarm"]
+enabled = true
+
+# seq 0
+[[testcases]]
+name = "ping-pong"
+instances = { min = 2, max = 2, default = 2 }

--- a/pkg/sidecar/link.go
+++ b/pkg/sidecar/link.go
@@ -181,10 +181,43 @@ func (l *NetlinkLink) Shape(shape sync.LinkShape) error {
 	return nil
 }
 
-// Set the links address.
+// NOTE: None of the following methods are currently used. They exist for future
+// non-docker runners.
+
+// AddrAdd adds an address to the link.
+//
 // NOTE: This won't work in docker; use docker connect/disconnect.
-func (l *NetlinkLink) SetAddr(ip *net.IPNet) error {
-	return l.handle.AddrReplace(l.Link, &netlink.Addr{IPNet: ip})
+func (l *NetlinkLink) AddrAdd(ip *net.IPNet) error {
+	return l.handle.AddrAdd(l.Link, &netlink.Addr{IPNet: ip})
+}
+
+// AddrDel removes an address from the link.
+//
+// NOTE: This won't work in docker; use docker connect/disconnect.
+func (l *NetlinkLink) AddrDel(ip *net.IPNet) error {
+	return l.handle.AddrAdd(l.Link, &netlink.Addr{IPNet: ip})
+}
+
+// ListV4 lists all IPv4 addresses associated with the link.
+func (l *NetlinkLink) ListV4() ([]*net.IPNet, error) {
+	return l.list(netlink.FAMILY_V4)
+}
+
+// ListV6 lists all IPv6 addresses associated with the link.
+func (l *NetlinkLink) ListV6() ([]*net.IPNet, error) {
+	return l.list(netlink.FAMILY_V6)
+}
+
+func (l *NetlinkLink) list(family int) ([]*net.IPNet, error) {
+	addrs, err := l.handle.AddrList(l.Link, family)
+	if err != nil {
+		return nil, err
+	}
+	res := make([]*net.IPNet, len(addrs))
+	for i, addr := range addrs {
+		res[i] = addr.IPNet
+	}
+	return res, nil
 }
 
 // Up sets the link up.

--- a/pkg/sidecar/link.go
+++ b/pkg/sidecar/link.go
@@ -195,7 +195,7 @@ func (l *NetlinkLink) AddrAdd(ip *net.IPNet) error {
 //
 // NOTE: This won't work in docker; use docker connect/disconnect.
 func (l *NetlinkLink) AddrDel(ip *net.IPNet) error {
-	return l.handle.AddrAdd(l.Link, &netlink.Addr{IPNet: ip})
+	return l.handle.AddrDel(l.Link, &netlink.Addr{IPNet: ip})
 }
 
 // ListV4 lists all IPv4 addresses associated with the link.

--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -114,19 +114,16 @@ func SetupNetwork(ctx context.Context, runenv *runtime.RunEnv, watcher *sync.Wat
 	if !runenv.TestSidecar {
 		return nil
 	}
+
+	// Wait for the network to be initialized.
+	if err := sync.WaitNetworkInitialized(ctx, runenv, watcher); err != nil {
+		return err
+	}
+
 	// TODO: just put the hostname inside the runenv?
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
-	}
-
-	// Wait for the network to be ready.
-	//
-	// Technically, we don't need to do this as configuring the network will
-	// block on it being ready.
-	err = <-watcher.Barrier(ctx, "network-initialized", int64(runenv.TestInstanceCount))
-	if err != nil {
-		return fmt.Errorf("failed to initialize network: %w", err)
 	}
 
 	writer.Write(sync.NetworkSubtree(hostname), &sync.NetworkConfig{

--- a/plans/network/README.md
+++ b/plans/network/README.md
@@ -1,0 +1,4 @@
+# Network
+
+The network test plan makes sure the testground network control logic (sidecar)
+works properly.

--- a/plans/network/go.mod
+++ b/plans/network/go.mod
@@ -1,0 +1,14 @@
+module github.com/ipfs/testground/plans/network
+
+go 1.13
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000
+	github.com/ipfs/testground/sdk/sync v0.0.0-00010101000000-000000000000
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+)
+
+replace github.com/ipfs/testground/sdk/runtime => ../../sdk/runtime
+replace github.com/ipfs/testground/sdk/sync => ../../sdk/sync

--- a/plans/network/main.go
+++ b/plans/network/main.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/ipfs/testground/sdk/sync"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	runenv := runtime.CurrentRunEnv()
+	if runenv.TestCaseSeq < 0 {
+		panic("test case sequence number not set")
+	}
+
+	if runenv.TestCaseSeq != 0 {
+		runenv.Abort("aborting")
+		return
+	}
+
+	watcher, writer := sync.MustWatcherWriter(runenv)
+	defer watcher.Close()
+	defer writer.Close()
+
+	if !runenv.TestSidecar {
+		runenv.OK()
+		return
+	}
+
+	if err := sync.WaitNetworkInitialized(ctx, runenv, watcher); err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	oldAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	config := sync.NetworkConfig{
+		// Control the "default" network. At the moment, this is the only network.
+		Network: "default",
+
+		// Enable this network. Setting this to false will disconnect this test
+		// instance from this network. You probably don't want to do that.
+		Enable: true,
+		Default: sync.LinkShape{
+			Latency:   100 * time.Millisecond,
+			Bandwidth: 1 << 20, // 1Mib
+		},
+		State: "network-configured",
+	}
+
+	_, err = writer.Write(sync.NetworkSubtree(hostname), &config)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	err = <-watcher.Barrier(ctx, config.State, int64(runenv.TestInstanceCount))
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	// Make sure that the IP addresses don't change unless we request it.
+
+	newAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	if !sameAddrs(oldAddrs, newAddrs) {
+		runenv.Abort("interfaces changed")
+		return
+	}
+
+	// Get a sequence number
+	seq, err := writer.Write(&sync.Subtree{
+		GroupKey:    "ip-allocation",
+		PayloadType: reflect.TypeOf(""),
+		KeyFunc: func(val interface{}) string {
+			return val.(string)
+		},
+	}, hostname)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	runenv.Message("I am %d", seq)
+
+	if seq >= 1<<16 {
+		runenv.Abort("test-case only supports 2**16 instances")
+		return
+	}
+
+	ipC := byte((seq >> 8) + 1)
+	ipD := byte(seq)
+
+	config.IPv4 = &*runenv.TestSubnet
+	config.IPv4.IP = append(config.IPv4.IP[0:2:2], ipC, ipD)
+	config.State = "ip-changed"
+
+	var (
+		listener *net.TCPListener
+		conn     *net.TCPConn
+	)
+	if seq == 1 {
+		listener, err = net.ListenTCP("tcp4", &net.TCPAddr{Port: 1234})
+		if err != nil {
+			runenv.Abort(err)
+			return
+		}
+		defer listener.Close()
+	}
+
+	_, err = writer.Write(sync.NetworkSubtree(hostname), &config)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	err = <-watcher.Barrier(ctx, config.State, int64(runenv.TestInstanceCount))
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	switch seq {
+	case 1:
+		conn, err = listener.AcceptTCP()
+	case 2:
+		conn, err = net.DialTCP("tcp4", nil, &net.TCPAddr{
+			IP:   append(config.IPv4.IP[:3:3], 1),
+			Port: 1234,
+		})
+	default:
+		runenv.Abort("expected at most two test instances")
+		return
+	}
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	defer conn.Close()
+
+	// trying to measure latency here.
+	conn.SetNoDelay(true)
+
+	pingPong := func(test string, rttMin, rttMax time.Duration) error {
+		buf := make([]byte, 1)
+
+		runenv.Message("waiting until ready")
+		// wait till both sides are ready
+		_, err = conn.Write([]byte{0})
+		if err != nil {
+			return err
+		}
+		_, err = conn.Read(buf)
+		if err != nil {
+			return err
+		}
+
+		start := time.Now()
+
+		runenv.Message("writing my id")
+		// write sequence number.
+		_, err = conn.Write([]byte{byte(seq)})
+		if err != nil {
+			return err
+		}
+
+		runenv.Message("reading their id")
+		// pong other sequence number
+		_, err = conn.Read(buf)
+		if err != nil {
+			return err
+		}
+		runenv.Message("returning their id")
+		_, err = conn.Write(buf)
+		if err != nil {
+			return err
+		}
+
+		runenv.Message("reading my id")
+		// read our sequence number
+		_, err = conn.Read(buf)
+		if err != nil {
+			return err
+		}
+
+		runenv.Message("done")
+
+		// stop
+		end := time.Now()
+
+		// check the sequence number.
+		if buf[0] != byte(seq) {
+			return fmt.Errorf("read unexpected value")
+		}
+
+		// check the RTT
+		rtt := end.Sub(start)
+		if rtt < rttMin || rtt > rttMax {
+			return fmt.Errorf("expected an RTT between %s and %s, got %s", rttMin, rttMax, rtt)
+		}
+		runenv.Message("ping RTT was %s [%s, %s]", rtt, rttMin, rttMax)
+
+		state := sync.State("ping-pong-" + test)
+
+		// Don't reconfigure the network until we're done with the first test.
+		writer.SignalEntry(state)
+		err = <-watcher.Barrier(ctx, state, int64(runenv.TestInstanceCount))
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	err = pingPong("200", 200*time.Millisecond, 205*time.Millisecond)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	config.Default.Latency = 10 * time.Millisecond
+	config.State = "latency-reduced"
+
+	_, err = writer.Write(sync.NetworkSubtree(hostname), &config)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	err = <-watcher.Barrier(ctx, config.State, int64(runenv.TestInstanceCount))
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	err = pingPong("10", 20*time.Millisecond, 25*time.Millisecond)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	runenv.OK()
+}
+
+func sameAddrs(a, b []net.Addr) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aset := make(map[string]bool, len(a))
+	for _, addr := range a {
+		aset[addr.String()] = true
+	}
+	for _, addr := range b {
+		if !aset[addr.String()] {
+			return false
+		}
+	}
+	return true
+}

--- a/sdk/sync/helper.go
+++ b/sdk/sync/helper.go
@@ -1,0 +1,19 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+// WaitNetworkInitialized waits for the sidecar to initialize the network, if the sidecar is enabled.
+func WaitNetworkInitialized(ctx context.Context, runenv *runtime.RunEnv, watcher *Watcher) error {
+	if runenv.TestSidecar {
+		err := <-watcher.Barrier(ctx, "network-initialized", int64(runenv.TestInstanceCount))
+		if err != nil {
+			return fmt.Errorf("failed to initialize network: %w", err)
+		}
+	}
+	return nil
+}

--- a/sdk/sync/presets.go
+++ b/sdk/sync/presets.go
@@ -90,9 +90,15 @@ type NetworkConfig struct {
 	// Network is the name of the network to configure
 	Network string
 
-	// IP sets the IP address of this network device. If unspecified, docker
-	// will assign a random IP address.
-	IP *net.IPNet
+	// IPv4 and IPv6 set the IP addresses of this network device. If
+	// unspecified, the sidecar will leave them alone.
+	//
+	// Your test-case will be assigned a B block in the range
+	// 16.0.0.1-32.0.0.0. X.Y.0.1 will always be reserved for the gateway
+	// and shouldn't be used by the test.
+	//
+	// TODO: IPv6 is currently not supported.
+	IPv4, IPv6 *net.IPNet
 
 	// Enable enables this network device.
 	Enable bool


### PR DESCRIPTION
* Make it possible to set IP addresses with the sidecar (docker only, may not work in swarm?).
* Document the sidecar.
* Use a consistent subnet for the control network.
* Test the sidecar.

TODO:

* [x] Testing:
  * [x] Local docker - tested locally but I need to add an automated test.
  * [ ] Docker swarm - I'll need help with this one.

