### PR TITLE
adding dockerhub registry as an option

### DIFF
--- a/env-example.toml
+++ b/env-example.toml
@@ -9,6 +9,11 @@ access_key_id = "<aws access key id>"
 secret_access_key = "<aws secret access key>"
 region = "<aws region>"
 
+["dockerhub"]
+repo = "repo to be used for testground"
+username = "username"
+access_token = "docker hub access token"
+
 # You can set parameter for run or build strategies that apply in your
 # environment. They will be applied with the following precedence (highest
 # to lowest):

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -329,7 +329,10 @@ func pushToDockerHubRegistry(ctx context.Context, log *zap.SugaredLogger, client
 		Username: in.EnvConfig.DockerHub.Username,
 		Password: in.EnvConfig.DockerHub.AccessToken,
 	}
-	authBytes, _ := json.Marshal(auth)
+	authBytes, err := json.Marshal(auth)
+	if err != nil {
+		return err
+	}
 	authBase64 := base64.URLEncoding.EncodeToString(authBytes)
 
 	rc, err := client.ImagePush(ctx, uri, types.ImagePushOptions{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 // EnvConfig represents an environment configuration read
 type EnvConfig struct {
 	AWS             AWSConfig            `toml:"aws"`
+	DockerHub       DockerHubConfig      `toml:"dockerhub"`
 	BuildStrategies map[string]ConfigMap `toml:"build_strategies"`
 	RunStrategies   map[string]ConfigMap `toml:"run_strategies"`
 	Daemon          DaemonConfig         `toml:"daemon"`
@@ -46,6 +47,12 @@ type AWSConfig struct {
 	AccessKeyID     string `toml:"access_key_id"`
 	SecretAccessKey string `toml:"secret_access_key"`
 	Region          string `toml:"region"`
+}
+
+type DockerHubConfig struct {
+	Repo        string `toml:"repo"`
+	Username    string `toml:"username"`
+	AccessToken string `toml:"access_token"`
 }
 
 type DaemonConfig struct {


### PR DESCRIPTION
This PR is adding DockerHub as an option for Docker Registry.

Ideally we shouldn't use this as we will incur data transfer costs, but this is handy for development, until we set on a specific cloud provider (such as AWS, DO, GCP, etc.)

Ideally we should use an internal registry to the provider we pick - DO or GCP or other.