### PR TITLE
improve error messages when tests fail

### DIFF
--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -34,6 +34,6 @@ func TestDescribeUnexistingPlan(t *testing.T) {
 	})
 
 	if err == nil {
-		t.Fail()
+		t.Fatal("expected to get an err, due to non-existing test plan, but got nil")
 	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -62,7 +62,7 @@ func TestIncompatibleRun(t *testing.T) {
 	})
 
 	if err == nil {
-		t.Fail()
+		t.Fatal("expected to get an err, due to incompatible builder and runner, but got nil")
 	}
 }
 
@@ -82,6 +82,6 @@ func TestCompatibleRun(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fail()
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Tests failed at https://travis-ci.com/ipfs/testground/jobs/267609479 with:
```
--- FAIL: TestCompatibleRun (0.00s)
FAIL
```

I added a bit more context so that it is easier to understand when tests fail.