### PR TITLE
feat(cmd): use contexts everywhere

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -49,6 +49,9 @@ var BuildCommand = cli.Command{
 }
 
 func buildCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
 	if c.NArg() != 1 {
 		return errors.New("test plan name must be provided")
 	}
@@ -58,11 +61,10 @@ func buildCommand(c *cli.Context) error {
 		builder = c.Generic("builder").(*EnumValue).String()
 	)
 
-	api, cancel, err := setupClient()
+	api, err := setupClient(ctx)
 	if err != nil {
 		return err
 	}
-	defer cancel()
 
 	in, err := parseBuildInput(c)
 	if err != nil {
@@ -76,7 +78,7 @@ func buildCommand(c *cli.Context) error {
 		Builder:      builder,
 	}
 
-	resp, err := api.Build(context.Background(), req)
+	resp, err := api.Build(ctx, req)
 	if err != nil {
 		return fmt.Errorf("fatal error from daemon: %s", err)
 	}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	processContext     context.Context
+	processContextOnce sync.Once
+)
+
+func ProcessContext() context.Context {
+	processContextOnce.Do(func() {
+		var cancel context.CancelFunc
+		processContext, cancel = context.WithCancel(context.Background())
+
+		notify := make(chan os.Signal, 2)
+		signal.Notify(notify, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			defer signal.Stop(notify)
+
+			<-notify
+			cancel()
+
+			select {
+			case <-time.After(30 * time.Second):
+				fmt.Println("Timed out on shutdown, terminating...")
+			case <-notify:
+				fmt.Println("Received another interrupt before graceful shutdown, terminating...")
+			}
+			os.Exit(-1)
+		}()
+	})
+	return processContext
+}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -3,9 +3,6 @@ package cmd
 import (
 	"context"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/ipfs/testground/pkg/config"
@@ -22,6 +19,9 @@ var DaemonCommand = cli.Command{
 }
 
 func daemonCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
 	envcfg, err := config.GetEnvConfig()
 	if err != nil {
 		return err
@@ -33,27 +33,32 @@ func daemonCommand(c *cli.Context) error {
 
 	srv := server.New(envcfg.Daemon.Listen)
 
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	exiting := make(chan struct{})
+	defer close(exiting)
 
 	go func() {
-		logging.S().Infow("listen and serve", "addr", srv.Addr)
-		err := srv.ListenAndServe()
-		if err != nil && err != http.ErrServerClosed {
-			logging.S().Fatalw("server exited", "err", err)
+		select {
+		case <-ctx.Done():
+		case <-exiting:
+			// no need to shutdown in this case.
+			return
 		}
+
+		logging.S().Infow("shutting down rpc server")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			logging.S().Fatalw("failed to shut down rpc server", "err", err)
+		}
+		logging.S().Infow("rpc server stopped")
 	}()
 
-	<-done
-	logging.S().Infow("shutting down rpc server")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := srv.Shutdown(ctx); err != nil {
-		logging.S().Fatalw("failed to shut down rpc server", "err", err)
+	logging.S().Infow("listen and serve", "addr", srv.Addr)
+	err = srv.ListenAndServe()
+	if err == http.ErrServerClosed {
+		err = nil
 	}
-	logging.S().Infow("rpc server stopped")
-
-	return nil
+	return err
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -19,6 +19,9 @@ var DescribeCommand = cli.Command{
 }
 
 func describeCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
 	if c.NArg() == 0 {
 		_ = cli.ShowSubcommandHelp(c)
 		return errors.New("missing term to describe; " + server.TermExplanation)
@@ -26,16 +29,15 @@ func describeCommand(c *cli.Context) error {
 
 	term := c.Args().First()
 
-	api, cancel, err := setupClient()
+	api, err := setupClient(ctx)
 	if err != nil {
 		return err
 	}
-	defer cancel()
 
 	req := &client.DescribeRequest{
 		Term: term,
 	}
-	resp, err := api.Describe(context.Background(), req)
+	resp, err := api.Describe(ctx, req)
 	if err != nil {
 		return fmt.Errorf("fatal error from daemon: %s", err)
 	}

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"io"
 	"reflect"
 
@@ -18,7 +19,7 @@ type Runner interface {
 	ID() string
 
 	// Run runs a test case.
-	Run(job *RunInput, outputWriter io.Writer) (*RunOutput, error)
+	Run(ctx context.Context, job *RunInput, outputWriter io.Writer) (*RunOutput, error)
 
 	// ConfigType returns the configuration type of this runner.
 	ConfigType() reflect.Type

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"reflect"
@@ -204,7 +205,7 @@ func (e *Engine) DoBuild(testplan string, builder string, input *api.BuildInput,
 	return res, err
 }
 
-func (e *Engine) DoRun(testplan string, testcase string, runner string, input *api.RunInput, output io.Writer) (*api.RunOutput, error) {
+func (e *Engine) DoRun(ctx context.Context, testplan string, testcase string, runner string, input *api.RunInput, output io.Writer) (*api.RunOutput, error) {
 	// Find the test plan.
 	plan := e.TestCensus().PlanByName(testplan)
 	if plan == nil {
@@ -287,7 +288,7 @@ func (e *Engine) DoRun(testplan string, testcase string, runner string, input *a
 	input.TestPlan = plan
 	input.EnvConfig = *e.envcfg
 
-	return run.Run(input, output)
+	return run.Run(ctx, input, output)
 }
 
 func coalesceConfigsIntoType(typ reflect.Type, cfgs ...map[string]interface{}) (interface{}, error) {

--- a/pkg/runner/cluster_nomad.go
+++ b/pkg/runner/cluster_nomad.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"io"
 	"reflect"
 
@@ -15,7 +16,7 @@ type NomadRunner struct {
 var _ api.Runner = (*NomadRunner)(nil)
 
 // TODO: NomadRunner.
-func (*NomadRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (*NomadRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
 	// TODO
 	panic("unimplemented")
 }

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -66,7 +66,7 @@ type ClusterSwarmRunner struct{}
 
 // TODO runner option to keep containers alive instead of deleting them after
 // the test has run.
-func (*ClusterSwarmRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
 	var (
 		image = input.ArtifactPath
 		seq   = input.Seq
@@ -75,7 +75,7 @@ func (*ClusterSwarmRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutpu
 	)
 
 	// global timeout of 1 minute for the scheduling.
-	ctx, cancelFn := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancelFn := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancelFn()
 
 	// Sanity check.

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -67,7 +67,7 @@ type LocalDockerRunner struct{}
 
 // TODO runner option to keep containers alive instead of deleting them after
 // the test has run.
-func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
 	var (
 		image = input.ArtifactPath
 		seq   = input.Seq
@@ -117,7 +117,7 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 		return nil, err
 	}
 
-	dataNetworkID, err := newDataNetwork(cli, logging.S(), runenv, "default")
+	dataNetworkID, err := newDataNetwork(ctx, cli, logging.S(), runenv, "default")
 	if err != nil {
 		return nil, err
 	}
@@ -133,20 +133,20 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 	}
 
 	// Ensure we have a control network.
-	controlNetworkID, err := ensureControlNetwork(cli, log)
+	controlNetworkID, err := ensureControlNetwork(ctx, cli, log)
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure that we have a testground-redis container; if not, create it.
-	_, err = ensureRedisContainer(cli, log, controlNetworkID)
+	_, err = ensureRedisContainer(ctx, cli, log, controlNetworkID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure that we have a testground-sidecar container; if not, we'll
 	// create it.
-	_, err = ensureSidecarContainer(cli, log, controlNetworkID)
+	_, err = ensureSidecarContainer(ctx, cli, log, controlNetworkID)
 	if err != nil {
 		if err.Error() == "image not found" {
 			newErr := errors.New("Docker image ipfs/testground not found, run `make docker-ipfs-testground`")
@@ -176,9 +176,9 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 		}
 
 		// Create the container.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-		res, err := cli.ContainerCreate(ctx, ccfg, hcfg, nil, name)
-		cancel()
+		cctx, ccancel := context.WithTimeout(ctx, 1*time.Minute)
+		res, err := cli.ContainerCreate(cctx, ccfg, hcfg, nil, name)
+		ccancel()
 
 		if err != nil {
 			break
@@ -187,7 +187,7 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 		containers = append(containers, res.ID)
 
 		// TODO: Remove this when we get the sidecar working. It'll do this for us.
-		err = attachContainerToNetwork(cli, res.ID, dataNetworkID)
+		err = attachContainerToNetwork(ctx, cli, res.ID, dataNetworkID)
 		if err != nil {
 			break
 		}
@@ -209,7 +209,7 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 	if !cfg.Unstarted {
 		log.Infow("starting containers", "count", len(containers))
 
-		g, ctx := errgroup.WithContext(context.Background())
+		g, ctx := errgroup.WithContext(ctx)
 		for _, id := range containers {
 			if err != nil {
 				break
@@ -237,7 +237,7 @@ func (*LocalDockerRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput
 
 	if !cfg.Background {
 		output := NewConsoleOutput()
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 		for _, id := range containers {
 			stream, err := cli.ContainerLogs(ctx, id, types.ContainerLogsOptions{
@@ -290,13 +290,13 @@ func deleteContainers(cli *client.Client, log *zap.SugaredLogger, ids []string) 
 	return merr.ErrorOrNil()
 }
 
-func ensureControlNetwork(cli *client.Client, log *zap.SugaredLogger) (id string, err error) {
-	return docker.EnsureBridgeNetwork(context.Background(), log, cli, "testground-control", true)
+func ensureControlNetwork(ctx context.Context, cli *client.Client, log *zap.SugaredLogger) (id string, err error) {
+	return docker.EnsureBridgeNetwork(ctx, log, cli, "testground-control", true)
 }
 
-func newDataNetwork(cli *client.Client, log *zap.SugaredLogger, env *runtime.RunEnv, name string) (id string, err error) {
+func newDataNetwork(ctx context.Context, cli *client.Client, log *zap.SugaredLogger, env *runtime.RunEnv, name string) (id string, err error) {
 	return docker.NewBridgeNetwork(
-		context.Background(),
+		ctx,
 		cli,
 		fmt.Sprintf("tg-%s-%s-%s-%s", env.TestPlan, env.TestCase, env.TestRun, name),
 		true,
@@ -310,8 +310,8 @@ func newDataNetwork(cli *client.Client, log *zap.SugaredLogger, env *runtime.Run
 }
 
 // ensureRedisContainer ensures there's a testground-redis container started.
-func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger, controlNetworkID string) (id string, err error) {
-	container, _, err := docker.EnsureContainer(context.Background(), log, cli, &docker.EnsureContainerOpts{
+func ensureRedisContainer(ctx context.Context, cli *client.Client, log *zap.SugaredLogger, controlNetworkID string) (id string, err error) {
+	container, _, err := docker.EnsureContainer(ctx, log, cli, &docker.EnsureContainerOpts{
 		ContainerName: "testground-redis",
 		ContainerConfig: &container.Config{
 			Image:      "redis",
@@ -331,8 +331,8 @@ func ensureRedisContainer(cli *client.Client, log *zap.SugaredLogger, controlNet
 }
 
 // ensureSidecarContainer ensures there's a testground-sidecar container started.
-func ensureSidecarContainer(cli *client.Client, log *zap.SugaredLogger, controlNetworkID string) (id string, err error) {
-	container, _, err := docker.EnsureContainer(context.Background(), log, cli, &docker.EnsureContainerOpts{
+func ensureSidecarContainer(ctx context.Context, cli *client.Client, log *zap.SugaredLogger, controlNetworkID string) (id string, err error) {
+	container, _, err := docker.EnsureContainer(ctx, log, cli, &docker.EnsureContainerOpts{
 		ContainerName: "testground-sidecar",
 		ContainerConfig: &container.Config{
 			Image:      "ipfs/testground:latest",
@@ -366,15 +366,15 @@ func ensureSidecarContainer(cli *client.Client, log *zap.SugaredLogger, controlN
 
 // attachContainerToNetwork attaches the provided container to the specified
 // network.
-func attachContainerToNetwork(cli *client.Client, containerID string, networkID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func attachContainerToNetwork(ctx context.Context, cli *client.Client, containerID string, networkID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	return cli.NetworkConnect(ctx, networkID, containerID, nil)
 }
 
 //nolint this function is unused, but it may come in handy.
-func detachContainerFromNetwork(cli *client.Client, containerID string, networkID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func detachContainerFromNetwork(ctx context.Context, cli *client.Client, containerID string, networkID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	return cli.NetworkDisconnect(ctx, networkID, containerID, true)
 }

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -20,7 +20,7 @@ type LocalExecutableRunner struct{}
 // LocalExecutableRunnerCfg is the configuration struct for this runner.
 type LocalExecutableRunnerCfg struct{}
 
-func (*LocalExecutableRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (*LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
 	var (
 		plan        = input.TestPlan
 		seq         = input.Seq
@@ -49,7 +49,7 @@ func (*LocalExecutableRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOu
 
 		// This context gets cancelled when the runner has finished, which in
 		// turn signals the temporary Redis instance to shut down.
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		cmd := exec.CommandContext(ctx, "redis-server", "--notify-keyspace-events", "$szxK")
@@ -107,7 +107,7 @@ func (*LocalExecutableRunner) Run(input *api.RunInput, ow io.Writer) (*api.RunOu
 		logging.S().Infow("starting test case instance", "testcase", name, "runenv", env)
 		id := fmt.Sprintf("instance %3d", i)
 
-		cmd := exec.Command(input.ArtifactPath)
+		cmd := exec.CommandContext(ctx, input.ArtifactPath)
 		stdout, _ := cmd.StdoutPipe()
 		stderr, _ := cmd.StderrPipe()
 		cmd.Env = env

--- a/pkg/server/run.go
+++ b/pkg/server/run.go
@@ -38,7 +38,7 @@ func (srv *Server) runHandler(w http.ResponseWriter, r *http.Request, log *zap.S
 		BuilderID:    req.BuilderID,
 	}
 
-	result, err := engine.DoRun(req.Plan, req.Case, req.Runner, runIn, ioutils.NewWriteFlusher(tgw))
+	result, err := engine.DoRun(r.Context(), req.Plan, req.Case, req.Runner, runIn, ioutils.NewWriteFlusher(tgw))
 	if err != nil {
 		tgw.WriteError("engine run error", "err", err)
 		return


### PR DESCRIPTION
This way, we:

* Obey interrupts.
* Cleanup on interrupts.