### PR TITLE
add REDIS_HOST to sidecar

### DIFF
--- a/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
@@ -31,6 +31,8 @@
     args:
       - sidecar
       - --runner docker
+    env:
+      REDIS_HOST: "testground-redis"
     networks:
       - control
     placement:

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -338,6 +338,7 @@ func ensureSidecarContainer(cli *client.Client, log *zap.SugaredLogger, controlN
 			Image:      "ipfs/testground:latest",
 			Entrypoint: []string{"testground"},
 			Cmd:        []string{"sidecar", "--runner", "docker"},
+			Env:        []string{"REDIS_HOST=testground-redis"},
 		},
 		HostConfig: &container.HostConfig{
 			NetworkMode: container.NetworkMode(controlNetworkID),


### PR DESCRIPTION
This PR is add REDIS_HOST as an ENV VAR when we setup infrastructure for Docker Swarm backend for Testground. Not sure if we will ever use these playbooks, but better keep them accurate when we can.

Related to https://github.com/ipfs/testground/issues/285

--

Regarding other `runners`:
1. `k8s` - REDIS_HOST will be configured within the resource that adds the sidecar to every machine, currently a `daemonset` which is defined at `infra/k8s/sidecar.yaml`
2. `local` ? If we run `testground` locally on Linux, we should be able to start `sidecar` as well. Who does that? Do we have any such scripts or code?