### PR TITLE
chore: do not fail on coverage diff of ~-5%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+comment: off
+
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to master should not make the overall
+        # project coverage decrease by more than 5%:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        # Be tolerant on slight code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        # in the github diff if they install the codecov browser
+        # extension:
+        # https://github.com/codecov/browser-extension
+        target: auto
+        threshold: 5%


### PR DESCRIPTION
This makes codecov more tolerant to coverage differences (-5%) so we don't have as many PRs failing at this time.

Borrowed from https://github.com/scikit-learn/scikit-learn/pull/9001/files

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>