### PR TITLE
daemon: rename Server.Start() to Serve(), and block.

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -55,8 +55,8 @@ func daemonCommand(c *cli.Context) error {
 		logging.S().Infow("rpc server stopped")
 	}()
 
-	logging.S().Infow("listen and serve", "addr", srv.Addr)
-	err = srv.Start()
+	logging.S().Infow("listen and serve", "addr", srv.Addr())
+	err = srv.Serve()
 	if err == http.ErrServerClosed {
 		err = nil
 	}

--- a/cmd/itest/common_test.go
+++ b/cmd/itest/common_test.go
@@ -18,11 +18,7 @@ func runSingle(t *testing.T, args ...string) error {
 		t.Fatal(err)
 	}
 
-	err = srv.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	go srv.Serve()                           //nolint
 	defer srv.Shutdown(context.Background()) //nolint
 
 	app := cli.NewApp()


### PR DESCRIPTION
We had a little merge kerfuffle where we merged code that expected Server.Start() to block, with code that didn't. This patch fixes that.