### PR TITLE
tgwriter: append key-values to message.

### DIFF
--- a/pkg/tgwriter/tgwriter.go
+++ b/pkg/tgwriter/tgwriter.go
@@ -2,9 +2,11 @@ package tgwriter
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/docker/docker/pkg/ioutils"
 	"io"
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -71,6 +73,15 @@ func (tgw *TgWriter) WriteResult(res interface{}) {
 
 func (tgw *TgWriter) WriteError(message string, keysAndValues ...interface{}) {
 	tgw.log.Warnw(message, keysAndValues...)
+
+	if len(keysAndValues) > 0 {
+		b := &strings.Builder{}
+		for i := 0; i < len(keysAndValues); i = i + 2 {
+			fmt.Fprintf(b, "%s: %s;", keysAndValues[i], keysAndValues[i+1])
+		}
+		kvs := b.String()
+		message = message + "; " + kvs[:len(kvs)-1]
+	}
 
 	pld := Msg{
 		Type: "error",


### PR DESCRIPTION
Fixes #304. New output:

```sh
⟩ ./testground -vv run dht/find-peers \
      --builder=exec:go \
      --runner=local:exec \
      --build-cfg bypass_cache=true \
      --instances=10 \
      --test-param n_find_peers=5 \
      --test-param bucket_size=10 \
      --test-param timeout_secs=300
Dec 17 13:38:24.314459	INFO	testground client initialized	{"addr": "localhost:8042"}
engine run error; err: instance count outside (10) of allowable range [16, 10000] for test find-peer
``` 