### PR TITLE
fix sidecar container and overlay network

### DIFF
--- a/infra/docker-swarm/ansible/.gitignore
+++ b/infra/docker-swarm/ansible/.gitignore
@@ -1,3 +1,5 @@
-inventories/
+inventories
 !inventories/group_vars/all.yaml
+roles/external
+!roles/external/requirements.yaml
 ansible.cfg

--- a/infra/docker-swarm/ansible/ansible.cfg-example
+++ b/infra/docker-swarm/ansible/ansible.cfg-example
@@ -3,6 +3,7 @@ inventory = inventories/$CLUSTER_NAME
 roles_path = roles:roles/external
 retry_files_enabled = no
 host_key_checking = False
+deprecation_warnings = False
 private_key_file = ~/.ssh/$PRV_KEY_NAME
 
 [ssh_connection]

--- a/infra/docker-swarm/ansible/roles/filebeat/tasks/main.yml
+++ b/infra/docker-swarm/ansible/roles/filebeat/tasks/main.yml
@@ -25,9 +25,9 @@
     mode: 0644
   notify: restart filebeat
 
-- name: Ensure Filebeat is started and enabled at boot.
+- name: Ensure Filebeat is restarted and enabled at boot.
   service:
     name: filebeat
-    state: started
+    state: restarted
     enabled: true
 

--- a/infra/docker-swarm/ansible/roles/swarm-init/tasks/main.yml
+++ b/infra/docker-swarm/ansible/roles/swarm-init/tasks/main.yml
@@ -8,7 +8,7 @@
   register: worker_token
 
 - name: Get Manager node id 
-  shell: docker node ls | tail -1 | awk '{print $1}'
+  shell: docker node ls | grep Leader | tail -1 | awk '{print $1}'
   register: manager_id
 
 - name: Get Manager node private ip

--- a/infra/docker-swarm/ansible/roles/swarm-join/tasks/main.yml
+++ b/infra/docker-swarm/ansible/roles/swarm-join/tasks/main.yml
@@ -4,3 +4,7 @@
     advertise_addr: "{{ ansible_all_ipv4_addresses | ipaddr('172.16.0.0/16') | first }}"
     join_token: "{{ token }}"
     remote_addrs: [ "{{ manager }}:2377" ]
+
+# Pause for 10 seconds for worker nodes to connect to master
+- pause:
+    seconds: 10

--- a/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
@@ -1,3 +1,7 @@
+# Pause for 10 seconds for worker nodes to connect to master
+- pause:
+    seconds: 10
+
 - name: Create Testground overlay control network
   docker_network:
     name: control
@@ -6,6 +10,22 @@
     enable_ipv6: no
     ipam_config:
       - subnet: 10.1.0.0/16
+
+- pause:
+    seconds: 5
+
+# Propagate `control` network on all hosts in the Swarm
+- name: Start sleep service
+  docker_swarm_service:
+    name: sleep
+    image: "alpine"
+    mode: global
+    command: sleep 36000
+    networks:
+      - control
+
+- pause:
+    seconds: 5
 
 - name: Start Redis service
   docker_swarm_service:
@@ -22,20 +42,6 @@
       constraints:
         - node.labels.TGRole == redis
 
-- name: Start sidecar service
-  docker_swarm_service:
-    name: testground-sidecar
-    image: "ipfs/testground:latest"
-    mode: global
-    command: testground
-    args:
-      - sidecar
-      - --runner docker
-    env:
-      REDIS_HOST: "testground-redis"
-    networks:
-      - control
-    placement:
-      constraints:
-        - node.labels.TGRole == worker
-
+# Pause for 20 seconds after starting redis
+- pause:
+    seconds: 20

--- a/infra/docker-swarm/ansible/roles/testground-sidecar/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-sidecar/tasks/main.yaml
@@ -10,6 +10,8 @@
       - name: "control"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+    env:
+      REDIS_HOST: "testground-redis"
     capabilities:
       - sys_admin
       - net_admin

--- a/infra/docker-swarm/ansible/roles/testground-sidecar/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-sidecar/tasks/main.yaml
@@ -1,0 +1,20 @@
+- name: Start Testground sidecar container
+  docker_container:
+    name: "testground-sidecar"
+    image: "ipfs/testground:edge"
+    state: started
+    restart_policy: always
+    stop_timeout: "10"
+    pid_mode: "host"
+    networks:
+      - name: "control"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    capabilities:
+      - sys_admin
+      - net_admin
+    command: 
+      - "-vv"
+      - "sidecar"
+      - "--runner"
+      - "docker"

--- a/infra/docker-swarm/ansible/setup.yaml
+++ b/infra/docker-swarm/ansible/setup.yaml
@@ -49,7 +49,7 @@
 - hosts: role_worker
   name: Join workers to Docker Swarm cluster
   become: true
-  gather_facts: false
+  gather_facts: False
   vars:
       token: "{{ hostvars[groups['role_manager'][0]]['worker_token']['stdout'] }}"
       manager: "{{ hostvars[groups['role_manager'][0]]['manager_ipv4']['stdout'] }}"
@@ -60,7 +60,7 @@
 - hosts: role_redis
   name: Join Redis to Docker Swarm cluster
   become: true
-  gather_facts: true
+  gather_facts: False
   vars:
       token: "{{ hostvars[groups['role_manager'][0]]['worker_token']['stdout'] }}"
       manager: "{{ hostvars[groups['role_manager'][0]]['manager_ipv4']['stdout'] }}"

--- a/infra/docker-swarm/ansible/setup.yaml
+++ b/infra/docker-swarm/ansible/setup.yaml
@@ -49,7 +49,7 @@
 - hosts: role_worker
   name: Join workers to Docker Swarm cluster
   become: true
-  gather_facts: False
+  gather_facts: false
   vars:
       token: "{{ hostvars[groups['role_manager'][0]]['worker_token']['stdout'] }}"
       manager: "{{ hostvars[groups['role_manager'][0]]['manager_ipv4']['stdout'] }}"
@@ -60,7 +60,7 @@
 - hosts: role_redis
   name: Join Redis to Docker Swarm cluster
   become: true
-  gather_facts: False
+  gather_facts: true
   vars:
       token: "{{ hostvars[groups['role_manager'][0]]['worker_token']['stdout'] }}"
       manager: "{{ hostvars[groups['role_manager'][0]]['manager_ipv4']['stdout'] }}"
@@ -74,4 +74,19 @@
   gather_facts: true
   roles:
     - swarm-label
+
+- hosts: role_manager
+  name: Run Testground services (Redis and control overlay network)
+  become: true
+  gather_facts: true
+  roles:
     - testground-services
+  tags: [testground-services]
+
+- hosts: role_worker
+  name: Run sidecar container on every worker node
+  become: true
+  gather_facts: true
+  roles:
+    - testground-sidecar
+  tags: [testground-sidecar]

--- a/infra/docker-swarm/ansible/templates/filebeat.yml.j2
+++ b/infra/docker-swarm/ansible/templates/filebeat.yml.j2
@@ -15,7 +15,7 @@ filebeat.inputs:
       #close_removed: false
       #clean_removed: false
       #scan_frequency: 1s
-  scan_frequency: 1s
+  scan_frequency: 5s
 
 #============================= Filebeat modules ===============================
 


### PR DESCRIPTION
Some Ansible improvements and bug fixes we found today:
1. We can't run `sidecar` as a service, because we need to set up the host process namespace, capabilities, etc. - so we run it as a container.
2. Due to 1, we have to create the overlay network on all worker nodes. This is why we run a dummy `sleep` container to propagate the overlay network to all workers. Docker overlay networks are propagated lazily until a service needs them, and here we need the `control` network in the `sidecar` container.
3. Fix on getting the `Leader` IP - this was racy, and worked only if the leader hadn't added any workers.