### PR TITLE
feat: consistently use predefined network blocks

### DIFF
--- a/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
@@ -9,7 +9,7 @@
     attachable: yes
     enable_ipv6: no
     ipam_config:
-      - subnet: 10.1.0.0/16
+      - subnet: 192.168.0.0/16
 
 - pause:
     seconds: 5

--- a/pkg/docker/network.go
+++ b/pkg/docker/network.go
@@ -7,15 +7,19 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 )
 
-func NewBridgeNetwork(ctx context.Context, cli *client.Client, name string, internal bool, labels map[string]string) (id string, err error) {
+func NewBridgeNetwork(ctx context.Context, cli *client.Client, name string, internal bool, labels map[string]string, config ...network.IPAMConfig) (id string, err error) {
 	res, err := cli.NetworkCreate(ctx, name, types.NetworkCreate{
 		Driver:     "bridge",
 		Attachable: true,
 		Internal:   internal,
 		Labels:     labels,
+		IPAM: &network.IPAM{
+			Config: config,
+		},
 	})
 	if err != nil {
 		return "", err
@@ -23,7 +27,7 @@ func NewBridgeNetwork(ctx context.Context, cli *client.Client, name string, inte
 	return res.ID, nil
 }
 
-func EnsureBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, name string, internal bool) (id string, err error) {
+func EnsureBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, name string, internal bool, config ...network.IPAMConfig) (id string, err error) {
 	opts := types.NetworkListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("name", name),
@@ -41,5 +45,5 @@ func EnsureBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *clien
 		return network.ID, nil
 	}
 
-	return NewBridgeNetwork(ctx, cli, name, internal, nil)
+	return NewBridgeNetwork(ctx, cli, name, internal, nil, config...)
 }

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -1,0 +1,26 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Use consistent IP address ranges for both the data and the control subnet.
+// _which_
+var (
+	controlSubnet  = "192.168.0.0/16"
+	controlGateway = "192.168.0.1"
+)
+
+func nextDataNetwork(lenNetworks int) (string, string, error) {
+	if lenNetworks > 4095 {
+		return "", "", errors.New("space exhausted")
+	}
+	a := 16 + lenNetworks/256
+	b := 0 + lenNetworks%256
+
+	subnet := fmt.Sprintf("%d.%d.0.0/16", a, b)
+	gateway := fmt.Sprintf("%d.%d.0.1", a, b)
+
+	return subnet, gateway, nil
+}

--- a/pkg/runner/common_test.go
+++ b/pkg/runner/common_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestGetIPAMParams(t *testing.T) {
+func TestNextDataNetwork(t *testing.T) {
 	var tests = []struct {
 		lenNetworks int
 		subnet      string
@@ -21,7 +21,7 @@ func TestGetIPAMParams(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		subnet, gateway, err := getIPAMParams(tt.lenNetworks)
+		subnet, gateway, err := nextDataNetwork(tt.lenNetworks)
 		if subnet != tt.subnet || gateway != tt.gateway || (err != nil && !tt.hasError) {
 			t.Errorf("got subnet %s gateway %s, want %s and %s", subnet, gateway, tt.subnet, tt.gateway)
 		}

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -13,6 +13,10 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
+var (
+	_, localSubnet, _ = net.ParseCIDR("127.1.0.1/16")
+)
+
 var _ api.Runner = (*LocalExecutableRunner)(nil)
 
 type LocalExecutableRunner struct{}
@@ -86,6 +90,7 @@ func (*LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow i
 		TestInstanceCount:  input.Instances,
 		TestInstanceParams: input.Parameters,
 		TestSidecar:        false,
+		TestSubnet:         localSubnet,
 	}
 
 	// Spawn as many instances as the input parameters require.

--- a/sdk/sync/presets.go
+++ b/sdk/sync/presets.go
@@ -99,7 +99,9 @@ type NetworkConfig struct {
 
 	// Default is the default link shaping rule.
 	Default LinkShape
+
 	// Rules defines how traffic should be shaped to different subnets.
+	// TODO: This is not implemented.
 	Rules []LinkRule
 
 	// State will be signaled when the link changes are applied. Nodes can


### PR DESCRIPTION
Previously, we did this for docker swarm but not docker local.

This patch also exposes the chosen subnet to the test via the TestSubnet runtime environment variable. That way, the test can easily figure out which network interface is the "data" network and what IP addresses it should use (when asking the sidecar to assign an IP address).

factored out of https://github.com/ipfs/testground/pull/271

(also tested in that PR via the sidecar test)