### PR TITLE
codecov set informational flag to true

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ coverage:
         # project coverage decrease by more than 5%:
         target: auto
         threshold: 5%
+        informational: true
     patch:
       default:
         # Be tolerant on slight code coverage diff on PRs to limit


### PR DESCRIPTION
From the docs, pointed out by @raulk

_informational_
Use Codecov in informational mode. Default is false. If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified. Informational mode is great to use if you want to expose codecov information to other developers in your pull request without necessarily gating PRs on that information.