### PR TITLE
test(network): fix flaky sidecar test

### DIFF
--- a/plans/network/main.go
+++ b/plans/network/main.go
@@ -255,7 +255,7 @@ func main() {
 		return
 	}
 
-	err = pingPong("10", 20*time.Millisecond, 25*time.Millisecond)
+	err = pingPong("10", 20*time.Millisecond, 30*time.Millisecond)
 	if err != nil {
 		runenv.Abort(err)
 		return


### PR DESCRIPTION
This test is very timing dependent. 30ms still demonstrates that the RTT is no longer 200ms.

fixes #325