### PR TITLE
add dht test plan compilation to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - GO111MODULE=on pushd .. && go get github.com/golangci/golangci-lint/cmd/golangci-lint && popd
         - golangci-lint run       # run a bunch of code checkers/linters in parallel
         - go build ./...          # build the project
+        - pushd ./plans/dht && go build ./... && popd         # build dht test plan
         - docker build -t ipfs/testground .
         - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./... # Run all the tests with the race detector enabled
         - go build .

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -39,7 +39,7 @@ instances = { min = 16, max = 10000, default = 16 }
   n_bootstrap   = { type = "int", desc = "number of bootstrap nodes", unit = "int", default = "1" }
   bucket_size   = { type = "int", desc = "routing table bucket size", unit = "peers", default = "2" }
   n_find_peers  = { type = "int", desc = "number of peers to find", unit = "peers", default = "1" }
-  timeout_secs  = { type = "int", desc = "test timeout", unit = "seconds", default = "30" }
+  timeout_secs  = { type = "int", desc = "test timeout", unit = "seconds", default = "60" }
 
 # seq 1
 [[testcases]]
@@ -47,13 +47,17 @@ name = "find-providers"
 instances = { min = 16, max = 250, default = 16 }
 
   [testcases.params]
-  bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
-  auto_refresh = { type = "bool", desc = "", unit = "bool" }
-  random_walk = { type = "bool", desc = "", unit = "bool" }
+  bucket_size = { type = "int", desc = "bucket size", unit = "peers", default = "2" }
+  auto_refresh = { type = "bool", desc = "", unit = "bool", default = "true" }
+  random_walk = { type = "bool", desc = "", unit = "bool", default = "false" }
+  timeout_secs  = { type = "int", desc = "test timeout", unit = "seconds", default = "60" }
   n_bootstrap = { type = "int", desc = "number of bootstrap nodes", unit = "int", default = "1" }
-  p_providing = { type = "int", desc = "", unit = "% of nodes" }
-  p_resolving = { type = "int", desc = "", unit = "% of nodes" }
-  p_failing = { type = "int", desc = "", unit = "% of nodes" }
+  n_find_peers = { type = "int", desc = "number of peers to find", unit = "int", default = "1" }
+  n_providing = { type = "int", desc = "nodes providing", unit = "int", default = "10" }
+  record_count = { type = "int", desc = "TODO DESCRIPTION", unit = "int", default = "5" }
+  #p_providing = { type = "int", desc = "", unit = "% of nodes" }
+  #p_resolving = { type = "int", desc = "", unit = "% of nodes" }
+  #p_failing = { type = "int", desc = "", unit = "% of nodes" }
 
 # seq 2
 [[testcases]]

--- a/plans/dht/test/find_peers.go
+++ b/plans/dht/test/find_peers.go
@@ -11,12 +11,12 @@ import (
 
 func FindPeers(runenv *runtime.RunEnv) {
 	opts := &SetupOpts{
-		Timeout:     time.Duration(runenv.IntParamD("timeout_secs", 60)) * time.Second,
-		RandomWalk:  runenv.BooleanParamD("random_walk", false),
-		NBootstrap:  runenv.IntParamD("n_bootstrap", 1),
-		NFindPeers:  runenv.IntParamD("n_find_peers", 1),
-		BucketSize:  runenv.IntParamD("bucket_size", 2),
-		AutoRefresh: runenv.BooleanParamD("auto_refresh", true),
+		Timeout:     time.Duration(runenv.IntParam("timeout_secs")) * time.Second,
+		RandomWalk:  runenv.BooleanParam("random_walk"),
+		NBootstrap:  runenv.IntParam("n_bootstrap"),
+		NFindPeers:  runenv.IntParam("n_find_peers"),
+		BucketSize:  runenv.IntParam("bucket_size"),
+		AutoRefresh: runenv.BooleanParam("auto_refresh"),
 	}
 
 	if opts.NFindPeers > runenv.TestInstanceCount {

--- a/plans/dht/test/find_providers.go
+++ b/plans/dht/test/find_providers.go
@@ -16,14 +16,14 @@ import (
 
 func FindProviders(runenv *runtime.RunEnv) {
 	opts := &SetupOpts{
-		Timeout:        time.Duration(runenv.IntParamD("timeout_secs", 60)) * time.Second,
-		RandomWalk:     runenv.BooleanParamD("random_walk", false),
-		NBootstrap:     runenv.IntParamD("n_bootstrap", 1),
-		NFindPeers:     runenv.IntParamD("n_find_peers", 1),
-		BucketSize:     runenv.IntParamD("bucket_size", 2),
-		AutoRefresh:    runenv.BooleanParamD("auto_refresh", true),
-		NodesProviding: runenv.IntParamD("nodes_providing", 10),
-		RecordCount:    runenv.IntParamD("record_count", 5),
+		Timeout:        time.Duration(runenv.IntParam("timeout_secs")) * time.Second,
+		RandomWalk:     runenv.BooleanParam("random_walk"),
+		NBootstrap:     runenv.IntParam("n_bootstrap"),
+		NFindPeers:     runenv.IntParam("n_find_peers"),
+		BucketSize:     runenv.IntParam("bucket_size"),
+		AutoRefresh:    runenv.BooleanParam("auto_refresh"),
+		NodesProviding: runenv.IntParam("nodes_providing"),
+		RecordCount:    runenv.IntParam("record_count"),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)


### PR DESCRIPTION
This PR is adding compilation of `dht test` as part of CI. We should be doing this for every test that we consider ready and maintained, at least for now, when tests are somewhat part of the `testground` codebase.

It is also fixing the code that gets the runtime config as we no longer have methods with default parameters - they are now taken from the `toml` config.