### PR TITLE
check len is > 0

### DIFF
--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -87,7 +87,7 @@ func EnsureContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cl
 		}
 		found := false
 		for _, summary := range images {
-			if summary.RepoTags[0] == opts.ContainerConfig.Image {
+			if len(summary.RepoTags) > 0 && summary.RepoTags[0] == opts.ContainerConfig.Image {
 				found = true
 				break
 			}


### PR DESCRIPTION
Not sure what `RepoTags` stands for, and even though Docker says it is required:

```
	// repo tags
	// Required: true
	RepoTags []string `json:"RepoTags"`
```

On my machine, `testground` was panicking when running:

`testground -vv run network/ping-pong --builder=docker:go --runner=local:docker`