### PR TITLE
fix: use a different control network

### DIFF
--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -11,7 +11,7 @@ The local runner will use your machine's local network interfaces. For now, this
 
 ## Control Network
 
-The "control network" runs on 192.168.0.1/16 and should only be used to
+The "control network" runs on 192.18.0.1/16 and should only be used to
 communicate with the sync service.
 
 After the sidecar is finished [initializing the

--- a/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
+++ b/infra/docker-swarm/ansible/roles/testground-services/tasks/main.yaml
@@ -9,7 +9,7 @@
     attachable: yes
     enable_ipv6: no
     ipam_config:
-      - subnet: 192.168.0.0/16
+      - subnet: 192.18.0.0/16
 
 - pause:
     seconds: 5

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -6,10 +6,11 @@ import (
 )
 
 // Use consistent IP address ranges for both the data and the control subnet.
-// _which_
+// This range was selected as it's specifically set aside for testing and
+// shouldn't conflict with any real networks.
 var (
-	controlSubnet  = "192.168.0.0/16"
-	controlGateway = "192.168.0.1"
+	controlSubnet  = "192.18.0.0/16"
+	controlGateway = "192.18.0.1"
 )
 
 func nextDataNetwork(lenNetworks int) (string, string, error) {


### PR DESCRIPTION
Otherwise, we can conflict with the host's _real_ IP addresses.

192.18.... should be safe as it's set aside for testing and benchmarking.