### PR TITLE
Log to a file

### DIFF
--- a/pkg/runner/console.go
+++ b/pkg/runner/console.go
@@ -1,12 +1,8 @@
 package runner
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/testground/pkg/logging"
@@ -15,137 +11,51 @@ import (
 	"github.com/logrusorgru/aurora"
 )
 
-// ConsoleOutput is a helper type for collecting test output and sending it to the console.
-type ConsoleOutput struct {
-	failed uint32
-
-	count  int
-	start  time.Time
+// ConsoleLogger is a logger that sends output to the console.
+type ConsoleLogger struct {
 	aurora aurora.Aurora
-	wg     sync.WaitGroup
 }
 
-// NewConsoleOutput constructs a new console output manager.
-func NewConsoleOutput() *ConsoleOutput {
-	return &ConsoleOutput{
-		start:  time.Now(),
+// NewConsoleLogger constructs a new console logger.
+func NewConsoleLogger() *ConsoleLogger {
+	return &ConsoleLogger{
 		aurora: aurora.NewAurora(logging.IsTerminal()),
 	}
 }
 
-// Wait waits for all running tests to finish and returns an error if any of
-// them failed.
-func (c *ConsoleOutput) Wait() error {
-	c.wg.Wait()
-	if c.failed > 0 {
-		return fmt.Errorf("%d nodes failed", c.failed)
-	}
-	return nil
-}
+// log an event to the console
+func (c *ConsoleLogger) msg(idx int, id string, elapsed time.Duration, evtType eventType, message ...interface{}) {
+	kind := [...]aurora.Value{
+		c.aurora.BgRed("ERROR").White(),
+		c.aurora.BgGreen("OK").White(),
+		c.aurora.BgRed("FAIL").White(),
+		c.aurora.BgBrightRed("INCOMPLETE").White(),
+		c.aurora.BgWhite("MESSAGE").Black(),
+		c.aurora.BgBlue("METRIC").White(),
+	}[evtType]
 
-func (c *ConsoleOutput) msg(idx int, id string, now time.Time, kind interface{}, message ...interface{}) {
-	eventTime := now.Sub(c.start)
-	if eventTime < 0 {
-		eventTime = 0
-	}
+	msg := fmt.Sprint(message...)
 	fmt.Printf("%9.4fs %10s %s %s\n",
-		float64(eventTime)/float64(time.Second),
+		float64(elapsed)/float64(time.Second),
 		kind,
 		c.aurora.Index(uint8(idx%15)+1, "<< "+id+" >>"),
-		fmt.Sprint(message...),
+		msg,
 	)
 }
 
-// FailStart should be used to report that a test failed to start.
-func (c *ConsoleOutput) FailStart(id string, message interface{}) {
-	idx := c.count
-	c.count++
-	atomic.AddUint32(&c.failed, 1)
-	c.msg(idx, id, time.Now(), c.aurora.BgBrightRed("INCOMPLETE").White(), "failed to start:", message)
+// log a metric to the console
+func (c *ConsoleLogger) metric(idx int, id string, elapsed time.Duration, metric *runtime.Metric) {
+	evtType := Metric
+	var message string
+	marshaled, err := json.Marshal(metric)
+	if err != nil {
+		evtType = Error
+		message = fmt.Sprintf("malformed metric: %s", err)
+	} else {
+		message = string(marshaled)
+	}
+	c.msg(idx, id, elapsed, evtType, message)
 }
 
-// Manage should be called on the standard output of all test plans. It will
-// send the events to standard out and record whether or not the test passed.
-func (c *ConsoleOutput) Manage(id string, stdout, stderr io.ReadCloser) {
-	idx := c.count
-	c.count++
-
-	var (
-		ERROR      = c.aurora.BgRed("ERROR").White()
-		OK         = c.aurora.BgGreen("OK").White()
-		FAIL       = c.aurora.BgRed("FAIL").White()
-		INCOMPLETE = c.aurora.BgBrightRed("INCOMPLETE").White()
-		MESSAGE    = c.aurora.BgWhite("MESSAGE").Black()
-		METRIC     = c.aurora.BgBlue("METRIC").White()
-	)
-
-	c.wg.Add(2)
-	go func() {
-		defer stderr.Close()
-		defer c.wg.Done()
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			c.msg(idx, id, time.Now(), ERROR, scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			c.msg(idx, id, time.Now(), ERROR, "stderr error: "+err.Error())
-		}
-	}()
-
-	go func() {
-		defer stdout.Close()
-		defer c.wg.Done()
-
-		printMsg := func(timestamp int64, kind interface{}, message ...interface{}) {
-			c.msg(idx, id, time.Unix(0, timestamp), kind, message...)
-		}
-
-		decoder := json.NewDecoder(stdout)
-		var event runtime.Event
-		var (
-			// track both in case a test-case is so broken that it
-			// reports both a success and a failure.
-			failed = false
-			ok     = false
-		)
-		for {
-			if err := decoder.Decode(&event); err != nil {
-				now := time.Now().UnixNano()
-				if err != io.EOF {
-					printMsg(now, ERROR, "stdout error: "+err.Error())
-					failed = true
-				}
-				if !ok && !failed {
-					// incomplete.
-					printMsg(event.Timestamp, INCOMPLETE)
-				}
-
-				if !ok || failed {
-					atomic.AddUint32(&c.failed, 1)
-				}
-
-				return
-			}
-
-			if event.Result != nil {
-				switch event.Result.Outcome {
-				case runtime.OutcomeOK:
-					ok = true
-					printMsg(event.Timestamp, OK, event.Result.Reason)
-				default:
-					failed = true
-					printMsg(event.Timestamp, FAIL, event.Result.Outcome, " ", event.Result.Reason)
-				}
-			} else if event.Metric != nil {
-				marshaled, err := json.Marshal(event.Metric)
-				if err != nil {
-					printMsg(event.Timestamp, ERROR, "malformed metric:", err)
-				} else {
-					printMsg(event.Timestamp, METRIC, string(marshaled))
-				}
-			} else {
-				printMsg(event.Timestamp, MESSAGE, event.Message)
-			}
-		}
-	}()
+func (c *ConsoleLogger) sync() {
 }

--- a/pkg/runner/eventmanager.go
+++ b/pkg/runner/eventmanager.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+type eventType int
+
+const (
+	Error eventType = iota
+	Ok
+	Fail
+	Incomplete
+	Message
+	Metric
+)
+
+func (et eventType) String() string {
+	return [...]string{"Error", "Ok", "Fail", "Incomplete", "Message", "Metric"}[et]
+}
+
+// eventLogger logs events to the console / a file / etc
+type eventLogger interface {
+	// msg logs a message
+	msg(idx int, id string, elapsed time.Duration, evtType eventType, message ...interface{})
+	// metric logs a metric
+	metric(idx int, id string, elapsed time.Duration, metric *runtime.Metric)
+	// sync is called just before logging completes
+	sync()
+}
+
+// EventManager is a helper type for collecting test output and sending it to a logger.
+type EventManager struct {
+	failed uint32
+
+	count  int
+	start  time.Time
+	wg     sync.WaitGroup
+	logger eventLogger
+}
+
+// NewEventManager constructs a new event manager.
+func NewEventManager(logger eventLogger) *EventManager {
+	return &EventManager{
+		start:  time.Now(),
+		logger: logger,
+	}
+}
+
+// Wait waits for all running tests to finish and returns an error if any of
+// them failed.
+func (c *EventManager) Wait() error {
+	c.wg.Wait()
+	if c.failed > 0 {
+		return fmt.Errorf("%d nodes failed", c.failed)
+	}
+	return nil
+}
+
+// FailStart should be used to report that a test failed to start.
+func (c *EventManager) FailStart(id string, message interface{}) {
+	idx := c.count
+	c.count++
+	atomic.AddUint32(&c.failed, 1)
+	c.msg(idx, id, time.Now(), Incomplete, "failed to start:", message)
+}
+
+// Manage should be called on the standard output of all test plans. It will
+// send the events to a logger and record whether or not the test passed.
+func (c *EventManager) Manage(id string, stdout, stderr io.ReadCloser) {
+	idx := c.count
+	c.count++
+
+	printMsg := func(timestamp int64, evtType eventType, message ...interface{}) {
+		now := time.Unix(0, timestamp)
+		c.msg(idx, id, now, evtType, message...)
+	}
+
+	c.wg.Add(2)
+	go func() {
+		defer stderr.Close()
+		defer c.wg.Done()
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			c.msg(idx, id, time.Now(), Error, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			c.msg(idx, id, time.Now(), Error, "stderr error: "+err.Error())
+		}
+	}()
+
+	go func() {
+		defer stdout.Close()
+		defer c.wg.Done()
+
+		decoder := json.NewDecoder(stdout)
+		var event runtime.Event
+		var (
+			// track both in case a test-case is so broken that it
+			// reports both a success and a failure.
+			failed = false
+			ok     = false
+		)
+		for {
+			if err := decoder.Decode(&event); err != nil {
+				now := time.Now().UnixNano()
+				if err != io.EOF {
+					printMsg(now, Error, "stdout error: "+err.Error())
+					failed = true
+				}
+				if !ok && !failed {
+					// incomplete.
+					printMsg(event.Timestamp, Incomplete)
+				}
+
+				if !ok || failed {
+					atomic.AddUint32(&c.failed, 1)
+				}
+
+				c.logger.sync()
+				return
+			}
+
+			if event.Result != nil {
+				switch event.Result.Outcome {
+				case runtime.OutcomeOK:
+					ok = true
+					printMsg(event.Timestamp, Ok, event.Result.Reason)
+				default:
+					failed = true
+					printMsg(event.Timestamp, Fail, event.Result.Outcome, " ", event.Result.Reason)
+				}
+			} else if event.Metric != nil {
+				now := time.Unix(0, event.Timestamp)
+				c.logger.metric(idx, id, c.getElapsed(now), event.Metric)
+			} else {
+				printMsg(event.Timestamp, Message, event.Message)
+			}
+		}
+	}()
+}
+
+func (c *EventManager) msg(idx int, id string, now time.Time, evtType eventType, message ...interface{}) {
+	c.logger.msg(idx, id, c.getElapsed(now), evtType, message...)
+}
+
+func (c *EventManager) getElapsed(now time.Time) time.Duration {
+	elapsed := now.Sub(c.start)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return elapsed
+}

--- a/pkg/runner/filelogger.go
+++ b/pkg/runner/filelogger.go
@@ -1,0 +1,58 @@
+package runner
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+	"go.uber.org/zap"
+)
+
+// FileLogger is a logger that sends output to a file.
+type FileLogger struct {
+	logger *zap.Logger
+}
+
+// NewFileLogger constructs a new file logger.
+func NewFileLogger(path string) *FileLogger {
+	cfg := zap.NewProductionConfig()
+	cfg.OutputPaths = []string{path}
+
+	// Disable caller, level and ts output
+	cfg.DisableCaller = true
+	cfg.EncoderConfig.LevelKey = ""
+	cfg.EncoderConfig.TimeKey = ""
+
+	logger, _ := cfg.Build()
+	return &FileLogger{logger}
+}
+
+// log an event to a file
+func (fl *FileLogger) msg(idx int, id string, elapsed time.Duration, evtType eventType, message ...interface{}) {
+	fl.logger.Info(fmt.Sprint(message...),
+		zap.String("instanceId", id),
+		zap.String("eventType", evtType.String()),
+		zap.Uint64("elapsed", uint64(elapsed)),
+	)
+}
+
+// log a metric to a file
+func (fl *FileLogger) metric(idx int, id string, elapsed time.Duration, metric *runtime.Metric) {
+	logger := fl.logger.With(
+		zap.String("instanceId", id),
+		zap.String("eventType", Metric.String()),
+		zap.Uint64("elapsed", uint64(elapsed)),
+
+		zap.Namespace("metric"),
+		zap.String("name", metric.Name),
+		zap.String("unit", metric.Unit),
+		zap.Int("improve_dir", metric.ImprovementDir),
+		zap.Float64("value", metric.Value),
+	)
+
+	logger.Info("")
+}
+
+func (fl *FileLogger) sync() {
+	_ = fl.logger.Sync()
+}

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -94,7 +94,7 @@ func (*LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow i
 	}
 
 	// Spawn as many instances as the input parameters require.
-	console := NewConsoleOutput()
+	console := NewEventManager(NewConsoleLogger())
 	commands := make([]*exec.Cmd, 0, instances)
 	defer func() {
 		for _, cmd := range commands {


### PR DESCRIPTION
To log to a file add the run-cfg parameter log_file, eg
`$ ./testground run bitswap-tuning/transfer --builder=docker:go --runner=local:docker --build-cfg bypass_cache=true --run-cfg log_file=/tmp/myfile.txt`