### PR TITLE
remove Docker Hub paragraph

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -107,15 +107,17 @@ kubectl apply -f sidecar.yaml
 ```
 
 
-## Configure Testground to push the built images to Docker Hub
+## Configure and run your Testground daemon
 
-1. Edit your `.env.toml` and add credentials for your Docker Hub account where the ready images will be pushed to. You will need an access token from Docker Hub for that step.
+```
+testground --vv daemon
+```
 
 
 ## Run a Testground testplan
 
 ```
-testground -vv run network/ping-pong \
+testground --vv run network/ping-pong \
     --builder=docker:go \
     --runner=cluster:k8s \
     --build-cfg bypass_cache=true \
@@ -128,7 +130,7 @@ testground -vv run network/ping-pong \
 or
 
 ```
-testground -vv run dht/find-peers \
+testground --vv run dht/find-peers \
     --builder=docker:go \
     --runner=cluster:k8s \
     --build-cfg push_registry=true \


### PR DESCRIPTION
I think this paragraph doesn't really belong in the `infra` docs. Also now we are back to AWS, so we can easily use the AWS ECR registry, which should be faster than Docker Hub.

I don't like that the commands are not directly runnable on user's machines, as I am referring to Docker Hub still, so there is still room for improvement there, and `docs` still assume some familiarity with Testground daemon/client configuration.