### PR TITLE
changing weave network to 16.0.0.0/4

### DIFF
--- a/infra/k8s/kops-weave/weave.yml
+++ b/infra/k8s/kops-weave/weave.yml
@@ -186,6 +186,8 @@ items:
                   value: --log-level=debug
                 - name: EXPECT_NPC
                   value: "0"
+                - name: IPALLOC_RANGE
+                  value: "16.0.0.0/4"
                 - name: HOSTNAME
                   valueFrom:
                     fieldRef:

--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: testground-sidecar
-        image: ipfs/testground:latest
+        image: ipfs/testground:edge
         command: ["testground"]
         args: ["--vv", "sidecar", "--runner", "k8s"]
         securityContext:

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -98,7 +98,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 	}
 
 	var err error
-	_, runenv.TestSubnet, err = net.ParseCIDR("10.33.10.0/24")
+	_, runenv.TestSubnet, err = net.ParseCIDR("16.0.10.0/24")
 	if err != nil {
 		return nil, err
 	}
@@ -170,6 +170,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
 									v1.ResourceMemory: resource.MustParse("30Mi"),
+									v1.ResourceCPU:    resource.MustParse("10m"),
 								},
 							},
 						},


### PR DESCRIPTION
Changing the `data` network to 16.0.0.0/4 as requested by @Stebalien 

TODO:
- [ ] The k8s runner also needs to be adjusted.