### PR TITLE
add dummy daemonset

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -79,13 +79,19 @@ kubectl apply -f ./flannel.yml
 kubectl apply -f ./genie-plugin.yaml
 ```
 
-9. Install Weave
+9. Install Dummy daemonset - we need a container on every worker node so that interface `cni0` is created, and Weave's initContainer can add a route to the Services CIDR
+
+```
+kubectl apply -f ./dummy.yaml
+```
+
+10. Install Weave
 
 ```
 kubectl apply -f ./weave.yml
 ```
 
-10. Destroy the cluster when you're done working on it
+11. Destroy the cluster when you're done working on it
 
 ```
 kops delete cluster $NAME --yes

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -128,7 +128,7 @@ testground --vv run network/ping-pong \
     --runner=cluster:k8s \
     --build-cfg bypass_cache=true \
     --build-cfg push_registry=true \
-    --build-cfg registry_type=dockerhub \
+    --build-cfg registry_type=aws \
     --run-cfg keep_service=true \
     --instances=2
 ```
@@ -140,7 +140,7 @@ testground --vv run dht/find-peers \
     --builder=docker:go \
     --runner=cluster:k8s \
     --build-cfg push_registry=true \
-    --build-cfg registry_type=dockerhub \
+    --build-cfg registry_type=aws \
     --run-cfg keep_service=true \
     --instances=16
 ```

--- a/infra/k8s/kops-weave/dummy.yml
+++ b/infra/k8s/kops-weave/dummy.yml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    k8s-app: dummy
+spec:
+  selector:
+    matchLabels:
+      name: dummy
+  template:
+    metadata:
+      annotations:
+        cni: "flannel"
+      labels:
+        name: dummy
+    spec:
+      containers:
+      - name: dummy
+        command: ["/bin/sleep", "3650d"]
+        image: governmentpaas/curl-ssl
+

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -170,6 +170,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
 									v1.ResourceMemory: resource.MustParse("30Mi"),
+									v1.ResourceCPU:    resource.MustParse("50m"),
 								},
 							},
 						},


### PR DESCRIPTION
Apparently we must have at least one pod , so that we get an IP address from the default k8s networking (Flannel), so that interface `cni0` is created.

We used this `cni0` interface later in the `initContainer` in `weave.yml` to add a route to all workers so that they can reach the services Kubernetes network (`redis-master`, etc.).