### PR TITLE
update redis endpoint from `redis-master` to `redis-headless`

### DIFF
--- a/infra/k8s/kops-weave/weave.yml
+++ b/infra/k8s/kops-weave/weave.yml
@@ -183,7 +183,7 @@ items:
                 - /home/weave/launch.sh
               env:
                 - name: EXTRA_ARGS
-                  value: --log-level=debug
+                  value: --log-level=info
                 - name: EXPECT_NPC
                   value: "0"
                 - name: IPALLOC_RANGE

--- a/infra/k8s/kops-weave/weave.yml
+++ b/infra/k8s/kops-weave/weave.yml
@@ -186,6 +186,8 @@ items:
                   value: --log-level=debug
                 - name: EXPECT_NPC
                   value: "0"
+                - name: IPALLOC_RANGE
+                  value: "10.0.0.0/8"
                 - name: HOSTNAME
                   valueFrom:
                     fieldRef:

--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
       - name: testground-sidecar
         image: ipfs/testground:edge
+        imagePullPolicy: Always
         command: ["testground"]
         args: ["--vv", "sidecar", "--runner", "k8s"]
         securityContext:
@@ -30,13 +31,13 @@ spec:
           privileged: true
         env:
         - name: REDIS_HOST
-          value: "redis-master"
+          value: "redis-headless"
         resources:
           limits:
-            memory: 200Mi
+            memory: 1024Mi
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 200m
+            memory: 1024Mi
         volumeMounts:
           - name: dockersock
             mountPath: "/var/run/docker.sock"

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -42,7 +42,7 @@ instances = { min = 16, max = 10000, default = 16 }
   n_bootstrap   = { type = "int", desc = "number of bootstrap nodes", unit = "int", default = 1 }
   bucket_size   = { type = "int", desc = "routing table bucket size", unit = "peers", default = 2 }
   n_find_peers  = { type = "int", desc = "number of peers to find", unit = "peers", default = 1 }
-  timeout_secs  = { type = "int", desc = "test timeout", unit = "seconds", default = 60 }
+  timeout_secs  = { type = "int", desc = "test timeout", unit = "seconds", default = 600 }
 
 # seq 1
 [[testcases]]

--- a/pkg/build/golang/Dockerfile.template
+++ b/pkg/build/golang/Dockerfile.template
@@ -62,4 +62,4 @@ COPY --from=0 /tmp/delete_me /tmp/go-ipfs/ipfs* /usr/local/bin/
 RUN rm -f /usr/local/bin/delete_me
 ENV PATH="/usr/local/bin:${PATH}"
 
-ENTRYPOINT [ "/testplan" ]
+ENTRYPOINT [ "/testplan", "--vv"]

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -30,6 +30,11 @@ var (
 	_ api.Runner = &ClusterK8sRunner{}
 )
 
+func init() {
+	// Avoid collisions in picking up subnets
+	rand.Seed(time.Now().UnixNano())
+}
+
 func homeDir() string {
 	home, _ := os.UserHomeDir()
 	return home

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -103,6 +103,11 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 		TestSidecar:        true,
 	}
 
+	// currently weave is not releaasing IP addresses upon container deletion - we get errors back when trying to
+	// use an already used IP address, even if the container has been removed
+	// this functionality should be refactored asap, when we understand how weave releases IPs (or why it doesn't release
+	// them when a container is removed/ and as soon as we decide how to manage `networks in-use` so that there are no
+	// collisions in concurrent testplan runs
 	var err error
 	b := 1 + rand.Intn(200)
 	_, runenv.TestSubnet, err = net.ParseCIDR(fmt.Sprintf("10.%d.0.0/16", b))

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -99,8 +99,8 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 	}
 
 	var err error
-	c := 1 + rand.Intn(200)
-	_, runenv.TestSubnet, err = net.ParseCIDR(fmt.Sprintf("10.32.%d.0/21", c))
+	b := 1 + rand.Intn(200)
+	_, runenv.TestSubnet, err = net.ParseCIDR(fmt.Sprintf("10.%d.0.0/16", b))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"path/filepath"
@@ -98,7 +99,8 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 	}
 
 	var err error
-	_, runenv.TestSubnet, err = net.ParseCIDR("10.33.10.0/24")
+	c := 1 + rand.Intn(200)
+	_, runenv.TestSubnet, err = net.ParseCIDR(fmt.Sprintf("10.32.%d.0/21", c))
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +109,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 
 	redisCfg := v1.EnvVar{
 		Name:  "REDIS_HOST",
-		Value: "redis-master",
+		Value: "redis-headless",
 	}
 
 	env = append(env, redisCfg)
@@ -169,8 +171,8 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 							Env:   env,
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse("30Mi"),
-									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+									v1.ResourceCPU:    resource.MustParse("100m"),
 								},
 							},
 						},


### PR DESCRIPTION
Something is wrong with the current k8s-sidecar runner. Network for `redis-master` (the control network) was not reachable in the `dht/find-peers` test when running the k8s-sidecar runner from `master`.
Resolution:
This is expected actually, because we do not have route for 100.64 services CIDR, we only have route to pod IPs.

---

This is just a heads-up for @dirkmc that you have to use `nonsens3/testground` (which has routes removal part disabled), in case you want to try `sidecar` with k8s today.

Will write follow up when I understand why `redis-master` is not reachable when we remove the routes - this should not be the case.