### PR TITLE
fix k8s_instance.go runner to remove routes

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -65,6 +65,9 @@ kops create cluster \
 ```
 
 5. Wait for `master` node to appear in `kubectl get nodes` - it will be in `NotReady` state as we haven't installed any Networking CNI yet.
+```
+watch 'kubectl get nodes -o wide'
+```
 
 6. Install Flannel
 
@@ -72,7 +75,12 @@ kops create cluster \
 kubectl apply -f ./infra/k8s/kops-weave/flannel.yml
 ```
 
-7. Wait for all nodes to appear in `kubectl get nodes` with `Ready` state.
+7. Wait for all nodes to appear in `kubectl get nodes` with `Ready` state, and for all pods in `kube-system` namespace to be `Running`.
+```
+watch 'kubectl get nodes -o wide'
+
+kubectl -n kube-system get pods -o wide
+```
 
 8. Install CNI-Genie
 
@@ -114,7 +122,9 @@ helm repo update
 helm install redis stable/redis --values ./infra/k8s/redis-values.yaml
 ```
 
-3. Create a `Sidecar` service on your Kubernetes cluster.
+3. Wait for `Redis` to be `Ready 1/1`
+
+4. Create a `Sidecar` service on your Kubernetes cluster.
 
 ```
 kubectl apply -f ./infra/k8s/sidecar.yaml

--- a/infra/k8s/redis-values.yaml
+++ b/infra/k8s/redis-values.yaml
@@ -552,11 +552,15 @@ configmap: |-
 ## Sysctl InitContainer
 ## used to perform sysctl operation to modify Kernel settings (needed sometimes to avoid warnings)
 sysctlImage:
-  enabled: false
-  command: []
+  enabled: true
+  command:
+  - /bin/sh
+  - -c
+  - |
+    sysctl -w net.core.somaxconn=10000
   registry: docker.io
-  repository: bitnami/minideb
-  tag: stretch
+  repository: busybox
+  tag: latest
   pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -153,7 +153,7 @@ func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *doc
 		return nil, fmt.Errorf("failed to list routes for control link %s", controlLink.Attrs().Name)
 	}
 
-	ip := redisRoute.Dst.IP
+	redisIP := redisRoute.Dst.IP
 
 	routesToBeDeleted := []netlink.Route{}
 
@@ -173,14 +173,14 @@ func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *doc
 		}
 
 		if route.Dst != nil {
-			if route.Dst.Contains(ip) {
+			if route.Dst.Contains(redisIP) {
 				newroute := route
 				newroute.Dst = &net.IPNet{
-					IP:   ip,
+					IP:   redisIP,
 					Mask: net.CIDRMask(32, 32),
 				}
 
-				logging.S().Debugw("adding redis route (ip)", "route.Src", newroute.Src, "route.Dst", newroute.Dst.String(), "gw", newroute.Gw, "container", container.ID)
+				logging.S().Debugw("adding redis route", "route.Src", newroute.Src, "route.Dst", newroute.Dst.String(), "gw", newroute.Gw, "container", container.ID)
 				if err := netlinkHandle.RouteAdd(&newroute); err != nil {
 					logging.S().Warnw("failed to add route while restricting gw route", "container", container.ID, "err", err.Error())
 				} else {


### PR DESCRIPTION
I had royally fucked up the `routes` adding and removal, probably it was working by coincidence, due to the small cluster that these were initially developed on.

I am not happy with the current state of `manageContainer`, but at least this is working now:

Routes on a `testplan` container start as:
```
default via 100.96.5.1 dev eth0
100.96.0.0/16 via 100.96.5.1 dev eth0
100.96.5.0/24 dev eth0 proto kernel scope link src 100.96.5.253
```

and become the following after we attach the `data` network:
```
default via 20.0.0.0 dev eth1
20.0.0.0 dev eth1 scope link
24.171.0.0/16 dev eth1 proto kernel scope link src 24.171.64.0
100.64.0.10 via 100.96.5.1 dev eth0
100.96.4.3 via 100.96.5.1 dev eth0
```

You can see that `100.96.0.0/16` is restricted to just redis at `100.96.4.3`, and we also have route to the DNS at `100.64.0.10`.

This is working fine from a node that is different to the redis node (100.96.4.1 vs 100.96.5.1) as well as on the node which hosts both redis and containers:

```
default via 100.96.4.1 dev eth0
100.96.0.0/16 via 100.96.4.1 dev eth0
100.96.4.0/24 dev eth0 proto kernel scope link src 100.96.4.198
```

becomes
```
default via 31.0.0.0 dev eth1
24.171.0.0/16 dev eth1 proto kernel scope link src 24.171.2.2
31.0.0.0 dev eth1 scope link
100.64.0.10 via 100.96.4.1 dev eth0
100.96.4.3 via 100.96.4.1 dev eth0
```

---

TODO in follow-up PRs:
- [ ] Ortogonal to this, we might want to add some affinity restrictions, so that `redis` is hosted on a node all by itself, and not sharing the node with 100 other testplan containers. (or we could just bump up redis' resource requirements essentially making sure that not much else fits on its machine).
- [ ] Add test so that we are sure that testplans are not reachable on the control network (100.96.0.0 currently), issue is already added by @Stebalien at https://github.com/ipfs/testground/issues/348
