### PR TITLE
DHT plan: avoid simultaneous connect issues with bootstrappers 

### DIFF
--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -257,8 +257,13 @@ func Bootstrap(ctx context.Context, runenv *runtime.RunEnv, watcher *sync.Watche
 		runenv.Message("bootstrap: got %d bootstrappers", len(bootstrapPeers))
 
 		if isBootstrapper {
-			// If we're a bootstrapper, connect to all of them.
-			toDial = bootstrapPeers
+			// If we're a bootstrapper, connect to all of them with IDs lexicographically less than us
+			toDial = make([]peer.AddrInfo, 0, len(bootstrapPeers))
+			for _, b := range bootstrapPeers {
+				if b.ID < dht.Host().ID() {
+					toDial = append(toDial, b)
+				}
+			}
 		} else {
 			// Otherwise, connect to a random one (based on our sequence number).
 			toDial = append(toDial, bootstrapPeers[int(seq)%len(bootstrapPeers)])


### PR DESCRIPTION
Currently all bootstrap nodes will dial each other. This can lead to simultaneous connection issues within libp2p where both bootstrappers end up dropping their connections to each other.

The solution used here is to have bootstrappers only dial those bootstrappers with peerIDs lexicographically than them.