### PR TITLE
Ensure k8s jobs get deleted when `keep_service=false`

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -197,6 +197,18 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 		return nil, err
 	}
 
+	defer func() {
+		log.Debugw("configuration for job", "keep_service", cfg.KeepService)
+		if cfg.KeepService {
+			log.Info("skipping removing the job due to user request")
+			return
+		}
+		err := clientset.BatchV1().Jobs(config.Namespace).Delete(jobName, &metav1.DeleteOptions{})
+		if err != nil {
+			log.Errorw("couldn't remove job", "job", jobName, "err", err)
+		}
+	}()
+
 	// Wait for job
 	start := time.Now()
 	for {
@@ -217,17 +229,6 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 		time.Sleep(2000 * time.Millisecond)
 	}
 
-	defer func() {
-		log.Debugw("configuration for job", "keep_service", cfg.KeepService)
-		if cfg.KeepService {
-			log.Info("skipping removing the job due to user request")
-			return
-		}
-		err := clientset.BatchV1().Jobs(config.Namespace).Delete(jobName, &metav1.DeleteOptions{})
-		if err != nil {
-			log.Errorw("couldn't remove job", "job", jobName, "err", err)
-		}
-	}()
 
 	out := &api.RunOutput{RunnerID: "smth"}
 	return out, nil


### PR DESCRIPTION
Running `testground` on a k8s cluster and passing in `--run-cfg keep_service=false` doesn't delete the batch job when a timeout occurs:

```
testground --vv run network/ping-pong \
    --builder=docker:go \
    --runner=cluster:k8s \
    --build-cfg bypass_cache=true \
    --build-cfg push_registry=true \
    --build-cfg registry_type=aws \
    --run-cfg keep_service=false \
    --instances=2
```
results in 
```
Jan 23 17:43:05.114810  WARN    engine run error        {"ruid": "921b8bcd", "err": "timeout"}
```

Attempting to run the same test again, we get an error about existing `jobs.batch "tg-network"`
```
Jan 23 17:47:06.776730  WARN    engine run error        {"ruid": "3e3823e9", "err": "jobs.batch \"tg-network\" already exists"}
``` 

This moves the `defer` function to run before the for loop to ensure that job cleanup happens when an error gets returned from the loop. 