### PR TITLE
feat: refactor result status handling

### DIFF
--- a/plans/bitswap-tuning/main.go
+++ b/plans/bitswap-tuning/main.go
@@ -5,16 +5,17 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv){
+var testCases = []func(*runtime.RunEnv) error{
 	test.Transfer,
 }
 
 func main() {
-	runenv := runtime.CurrentRunEnv()
+	runtime.Invoke(run)
+}
+
+func run(runenv *runtime.RunEnv) error {
 	if runenv.TestCaseSeq < 0 {
 		panic("test case sequence number not set")
 	}
-
-	// Demux to the right test case.
-	testCases[runenv.TestCaseSeq](runenv)
+	return testCases[runenv.TestCaseSeq](runenv)
 }

--- a/plans/chew-datasets/main.go
+++ b/plans/chew-datasets/main.go
@@ -21,7 +21,9 @@ var testCases = []utils.TestCase{
 }
 
 func main() {
-	runenv := runtime.CurrentRunEnv()
+	runtime.Invoke(run)
+}
+func run(runenv *runtime.RunEnv) error {
 	if runenv.TestCaseSeq < 0 {
 		panic("test case sequence number not set")
 	}
@@ -31,8 +33,7 @@ func main() {
 	cfg, err := utils.GetTestConfig(runenv, tc.AcceptFiles(), tc.AcceptDirs())
 	defer cfg.Cleanup()
 	if err != nil {
-		runenv.Abort(fmt.Errorf("could not retrieve test config: %s", err))
-		return
+		return fmt.Errorf("could not retrieve test config: %s", err)
 	}
 
 	ctx := context.Background()
@@ -66,8 +67,7 @@ func main() {
 			AddRepoOptions: addRepoOptions,
 		})
 		if err != nil {
-			runenv.Abort(fmt.Errorf("failed to get temp dir: %s", err))
-			return
+			return fmt.Errorf("failed to get temp dir: %s", err)
 		}
 
 		opts.IpfsInstance = ipfs
@@ -84,5 +84,5 @@ func main() {
 		opts.IpfsDaemon = client
 	}
 
-	tc.Execute(ctx, runenv, opts)
+	return tc.Execute(ctx, runenv, opts)
 }

--- a/plans/chew-datasets/test/ipfs_add_defaults.go
+++ b/plans/chew-datasets/test/ipfs_add_defaults.go
@@ -25,7 +25,7 @@ func (t *IpfsAddDefaults) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 
-func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 
@@ -46,8 +46,7 @@ func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, c
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
 
@@ -67,10 +66,8 @@ func (t *IpfsAddDefaults) Execute(ctx context.Context, runenv *runtime.RunEnv, c
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
-
-	runenv.OK()
+	return nil
 }

--- a/plans/chew-datasets/test/ipfs_add_dir_sharding.go
+++ b/plans/chew-datasets/test/ipfs_add_dir_sharding.go
@@ -28,7 +28,7 @@ func (t *IpfsAddDirSharding) AddRepoOptions() iptb.AddRepoOptions {
 	}
 }
 
-func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 
@@ -49,8 +49,7 @@ func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
 
@@ -65,10 +64,8 @@ func (t *IpfsAddDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
-
-	runenv.OK()
+	return nil
 }

--- a/plans/chew-datasets/test/ipfs_add_trickle_dag.go
+++ b/plans/chew-datasets/test/ipfs_add_trickle_dag.go
@@ -28,7 +28,7 @@ func (t *IpfsAddTrickleDag) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 
-func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 
@@ -54,8 +54,7 @@ func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv,
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
 
@@ -82,10 +81,9 @@ func (t *IpfsAddTrickleDag) Execute(ctx context.Context, runenv *runtime.RunEnv,
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 	}
 
-	runenv.OK()
+	return nil
 }

--- a/plans/chew-datasets/test/ipfs_file_store.go
+++ b/plans/chew-datasets/test/ipfs_file_store.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	config "github.com/ipfs/go-ipfs-config"
 	coreopts "github.com/ipfs/interface-go-ipfs-core/options"
@@ -28,7 +29,7 @@ func (t *IpfsFileStore) AddRepoOptions() iptb.AddRepoOptions {
 	}
 }
 
-func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 
@@ -48,8 +49,7 @@ func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg
 		})
 
 		if err != nil {
-			runenv.Abort(err)
-			return
+			return err
 		}
 
 		// TODO: Act II and Act III
@@ -61,5 +61,5 @@ func (t *IpfsFileStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg
 		runenv.Message("Not implemented yet")
 	}
 
-	runenv.OK()
+	return fmt.Errorf("not implemented")
 }

--- a/plans/chew-datasets/test/ipfs_mfs.go
+++ b/plans/chew-datasets/test/ipfs_mfs.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
@@ -23,7 +24,7 @@ func (t *IpfsMfs) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 
-func (t *IpfsMfs) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsMfs) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 		runenv.Message("Not Implemented Yet")
@@ -34,5 +35,5 @@ func (t *IpfsMfs) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *util
 		runenv.Message("Not Implemented Yet")
 	}
 
-	runenv.OK()
+	return fmt.Errorf("not implemented")
 }

--- a/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
+++ b/plans/chew-datasets/test/ipfs_mfs_dir_sharding.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
 	"github.com/ipfs/testground/sdk/iptb"
@@ -23,7 +24,7 @@ func (t *IpfsMfsDirSharding) AddRepoOptions() iptb.AddRepoOptions {
 	return nil
 }
 
-func (t *IpfsMfsDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsMfsDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 		runenv.Message("Not Implemented Yet")
@@ -34,5 +35,5 @@ func (t *IpfsMfsDirSharding) Execute(ctx context.Context, runenv *runtime.RunEnv
 		runenv.Message("Not Implemented Yet")
 	}
 
-	runenv.OK()
+	return fmt.Errorf("not implemented")
 }

--- a/plans/chew-datasets/test/ipfs_url_store.go
+++ b/plans/chew-datasets/test/ipfs_url_store.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	config "github.com/ipfs/go-ipfs-config"
 	utils "github.com/ipfs/testground/plans/chew-datasets/utils"
@@ -27,7 +28,7 @@ func (t *IpfsUrlStore) AddRepoOptions() iptb.AddRepoOptions {
 	}
 }
 
-func (t *IpfsUrlStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) {
+func (t *IpfsUrlStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg *utils.TestCaseOptions) error {
 	if cfg.IpfsInstance != nil {
 		runenv.Message("Running against the Core API")
 		runenv.Message("Not Implemented Yet")
@@ -38,5 +39,5 @@ func (t *IpfsUrlStore) Execute(ctx context.Context, runenv *runtime.RunEnv, cfg 
 		runenv.Message("Not Implemented Yet")
 	}
 
-	runenv.OK()
+	return fmt.Errorf("not implemented")
 }

--- a/plans/chew-datasets/utils/testcase.go
+++ b/plans/chew-datasets/utils/testcase.go
@@ -22,7 +22,7 @@ type TestCase interface {
 	AddRepoOptions() iptb.AddRepoOptions
 
 	// Execute executes the test case with the given options.
-	Execute(ctx context.Context, runenv *runtime.RunEnv, opts *TestCaseOptions)
+	Execute(ctx context.Context, runenv *runtime.RunEnv, opts *TestCaseOptions) error
 }
 
 // TestCaseOptions are the options to pass to the test case execute function.

--- a/plans/dht/main.go
+++ b/plans/dht/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv){
+var testCases = []func(*runtime.RunEnv) error{
 	test.FindPeers,
 	test.FindProviders,
 	test.ProvideStress,
@@ -13,11 +13,11 @@ var testCases = []func(*runtime.RunEnv){
 }
 
 func main() {
-	runenv := runtime.CurrentRunEnv()
+	runtime.Invoke(run)
+}
+func run(runenv *runtime.RunEnv) error {
 	if runenv.TestCaseSeq < 0 {
 		panic("test case sequence number not set")
 	}
-
-	// Demux to the right test case.
-	testCases[runenv.TestCaseSeq](runenv)
+	return testCases[runenv.TestCaseSeq](runenv)
 }

--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -492,6 +492,6 @@ func WaitRoutingTable(ctx context.Context, runenv *runtime.RunEnv, dht *kaddht.I
 func Teardown(ctx context.Context, runenv *runtime.RunEnv, watcher *sync.Watcher, writer *sync.Writer) {
 	err := Sync(ctx, runenv, watcher, writer, "end")
 	if err != nil {
-		runenv.Abort(err)
+		runenv.SLogger().Error("end sync failed", err)
 	}
 }

--- a/plans/dht/test/provide_stress.go
+++ b/plans/dht/test/provide_stress.go
@@ -1,12 +1,14 @@
 package test
 
 import (
+	"fmt"
+
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
 // TODO this entire test needs to be revisited.
 // ProvideStress implements the Provide Stress test case
-func ProvideStress(runenv *runtime.RunEnv) {
+func ProvideStress(runenv *runtime.RunEnv) error {
 	// 	// Test Parameters
 	// 	var (
 	// 		timeout     = time.Duration(runenv.IntParamD("timeout_secs", 60)) * time.Second
@@ -67,4 +69,5 @@ func ProvideStress(runenv *runtime.RunEnv) {
 	// 	runenv.Message("Provided all scheduled CIDs")
 
 	// 	runenv.OK()
+	return fmt.Errorf("unimplemented")
 }

--- a/plans/dht/test/store_get_value.go
+++ b/plans/dht/test/store_get_value.go
@@ -7,8 +7,6 @@ import (
 )
 
 // StoreGetValue - DEPRIORITIZED
-func StoreGetValue(runenv *runtime.RunEnv) {
-	fmt.Printf("Not implemented yet")
-
-	runenv.OK()
+func StoreGetValue(runenv *runtime.RunEnv) error {
+	return fmt.Errorf("not implemented")
 }

--- a/plans/placebo/main.go
+++ b/plans/placebo/main.go
@@ -1,18 +1,21 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
 func main() {
-	runenv := runtime.CurrentRunEnv()
+	runtime.Invoke(run)
+}
+func run(runenv *runtime.RunEnv) error {
 	if runenv.TestCaseSeq < 0 {
 		panic("test case sequence number not set")
 	}
 
-	if runenv.TestCaseSeq == 0 {
-		runenv.OK()
-	} else {
-		runenv.Abort("aborting")
+	if runenv.TestCaseSeq != 0 {
+		return fmt.Errorf("aborting")
 	}
+	return nil
 }

--- a/plans/smlbench/test/simple_add.go
+++ b/plans/smlbench/test/simple_add.go
@@ -29,30 +29,27 @@ func (tc *SimpleAddTC) Configure(runenv *runtime.RunEnv, spec *iptb.TestEnsemble
 	spec.AddNodesDefaultConfig(iptb.NodeOpts{Initialize: true, Start: true}, "adder")
 }
 
-func (tc *SimpleAddTC) Execute(runenv *runtime.RunEnv, ensemble *iptb.TestEnsemble) {
+func (tc *SimpleAddTC) Execute(runenv *runtime.RunEnv, ensemble *iptb.TestEnsemble) error {
 	node := ensemble.GetNode("adder")
 	client := node.Client()
 
 	filePath, err := runenv.CreateRandomFile(ensemble.TempDir(), tc.SizeBytes)
 	if err != nil {
-		runenv.Abort(err)
-		return
+		return err
 	}
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		runenv.Abort(err)
-		return
+		return err
 	}
 	defer os.Remove(filePath)
 
 	tstarted := time.Now()
 	_, err = client.Add(file)
 	if err != nil {
-		runenv.Abort(err)
-		return
+		return err
 	}
 
 	runenv.EmitMetric(utils.MetricTimeToAdd, float64(time.Now().Sub(tstarted)/time.Millisecond))
-	runenv.OK()
+	return nil
 }

--- a/plans/smlbench/utils/testcase.go
+++ b/plans/smlbench/utils/testcase.go
@@ -13,5 +13,5 @@ type SmallBenchmarksTestCase interface {
 	Configure(runenv *runtime.RunEnv, spec *iptb.TestEnsembleSpec)
 
 	// Execute executes the test case with the given ensemble.
-	Execute(runenv *runtime.RunEnv, ensemble *iptb.TestEnsemble)
+	Execute(runenv *runtime.RunEnv, ensemble *iptb.TestEnsemble) error
 }

--- a/sdk/runtime/output.go
+++ b/sdk/runtime/output.go
@@ -11,6 +11,7 @@ type Outcome string
 const (
 	OutcomeOK      = Outcome("ok")
 	OutcomeAborted = Outcome("aborted")
+	OutcomeCrashed = Outcome("crashed")
 )
 
 type MetricDefinition struct {
@@ -36,37 +37,7 @@ type Event struct {
 type Result struct {
 	Outcome Outcome `json:"outcome"`
 	Reason  string  `json:"reason,omitempty"`
-}
-
-// Abort outputs an abortion event, where reason is an object that will be
-// output as a message by stringing it.
-func (r *RunEnv) Abort(reason interface{}) {
-	evt := &Event{
-		RunEnv:    r,
-		Timestamp: time.Now().UnixNano(),
-		Result:    &Result{OutcomeAborted, fmt.Sprintf("%s", reason)},
-	}
-
-	bytes, err := json.Marshal(evt)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(string(bytes))
-}
-
-// OK outputs an OK event for this test execution.
-func (r *RunEnv) OK() {
-	evt := &Event{
-		RunEnv:    r,
-		Timestamp: time.Now().UnixNano(),
-		Result:    &Result{OutcomeOK, ""},
-	}
-
-	bytes, err := json.Marshal(evt)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println(string(bytes))
+	Stack   string  `json:"stack,omitempty"`
 }
 
 // Message prints out an informational message.

--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -1,0 +1,33 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"time"
+)
+
+// Invoke runs the passed test-case and reports the result.
+func Invoke(tc func(*RunEnv) error) {
+	runenv := CurrentRunEnv()
+
+	// Prepare the event.
+	evt := Event{RunEnv: runenv}
+	defer func() {
+		evt.Timestamp = time.Now().UnixNano()
+		if err := recover(); err != nil {
+			// Handle panics.
+			evt.Result = &Result{OutcomeCrashed, fmt.Sprintf("%s", err), string(debug.Stack())}
+		}
+		json.NewEncoder(os.Stdout).Encode(evt)
+	}()
+
+	err := tc(runenv)
+	switch err {
+	case nil:
+		evt.Result = &Result{OutcomeOK, "", ""}
+	default:
+		evt.Result = &Result{OutcomeAborted, err.Error(), ""}
+	}
+}


### PR DESCRIPTION
Mainly, return values from tests and drop `runtime.Abort` and `runtime.OK`.

1. We always just call OK at the end of the test so this is pretty useless.
2. We keep calling `Abort` then continuing with the test. An alternative here would be to make `Abort` _panic_. However, it's probably simpler to just return from the test.

Additionally, this change catches panics and returns stack traces in the structured logs.

This isn't a critical change, it has just been bugging me a bit and it was relatively simple to implement (for now, at least).