### PR TITLE
persist assets and logs

### DIFF
--- a/cmd/sidecar.go
+++ b/cmd/sidecar.go
@@ -32,6 +32,11 @@ var SidecarCommand = cli.Command{
 				Allowed: sidecar.GetRunners(),
 			},
 		},
+		cli.StringFlag{
+			Name:     "logs",
+			Required: false,
+			Usage:    `Specifies where container STDERR/STDOUT should be written. If unspecified, the sidecar doesn't save the logs`,
+		},
 	},
 }
 
@@ -39,5 +44,5 @@ func sidecarCommand(c *cli.Context) error {
 	if runtime.GOOS != "linux" {
 		return ErrNotLinux
 	}
-	return sidecar.Run(c.String("runner"))
+	return sidecar.Run(c.String("runner"), c.String("logs"))
 }

--- a/pkg/dockermanager/dockermanager.go
+++ b/pkg/dockermanager/dockermanager.go
@@ -3,6 +3,7 @@ package dockermanager
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -47,6 +48,15 @@ type Container struct {
 // Inspect inspects this docker container.
 func (dc *Container) Inspect(ctx context.Context) (types.ContainerJSON, error) {
 	return dc.Manager.ContainerInspect(ctx, dc.ID)
+}
+
+// Logs returns the logs for this docker container.
+func (dc *Container) Logs(ctx context.Context) (io.ReadCloser, error) {
+	return dc.Manager.ContainerLogs(ctx, dc.ID, types.ContainerLogsOptions{
+		ShowStderr: true,
+		ShowStdout: true,
+		Follow:     true,
+	})
 }
 
 // IsOnline returns whether or not the container is online.

--- a/pkg/runner/eventmanager.go
+++ b/pkg/runner/eventmanager.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +9,8 @@ import (
 	"time"
 
 	"github.com/ipfs/testground/sdk/runtime"
+
+	"go.uber.org/zap/zapcore"
 )
 
 type eventType int
@@ -89,12 +90,50 @@ func (c *EventManager) Manage(id string, stdout, stderr io.ReadCloser) {
 	go func() {
 		defer stderr.Close()
 		defer c.wg.Done()
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			c.msg(idx, id, time.Now(), Error, scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			c.msg(idx, id, time.Now(), Error, "stderr error: "+err.Error())
+
+		decoder := json.NewDecoder(stderr)
+		for {
+			event := make(map[string]json.RawMessage, 16)
+			if err := decoder.Decode(&event); err != nil {
+				if err != io.EOF {
+					now := time.Now().UnixNano()
+					printMsg(now, Error, "stderr error: "+err.Error())
+				}
+				return
+			}
+
+			var (
+				level               zapcore.Level
+				levelS              string
+				ts                  time.Time
+				name, code, message string
+			)
+
+			// Ignore everything less than a warning.
+			// Unless we can't parse the level.
+			_ = json.Unmarshal(event["L"], &levelS)
+			if err := level.Set(levelS); err == nil && level < zapcore.WarnLevel {
+				continue
+			}
+
+			// Dealing with errors just isn't worth it.
+			_ = json.Unmarshal(event["T"], &ts)
+			_ = json.Unmarshal(event["N"], &name)
+			_ = json.Unmarshal(event["C"], &code)
+			_ = json.Unmarshal(event["M"], &message)
+
+			// Filter down to the custom fields.
+			for _, k := range [...]string{
+				"L", "T", "N", "C", "M", "S",
+				"plan", "case", "run", "seq",
+				"repo", "commit", "branch",
+				"tag", "instances",
+			} {
+				delete(event, k)
+			}
+
+			fields, _ := json.Marshal(event)
+			c.msg(idx, id, ts, Error, fmt.Sprintf("%s %s %s\t%s", code, name, message, string(fields)))
 		}
 	}()
 

--- a/pkg/sidecar/docker_instance.go
+++ b/pkg/sidecar/docker_instance.go
@@ -152,6 +152,19 @@ func (d *DockerInstanceManager) manageContainer(ctx context.Context, container *
 		return nil, nil
 	}
 
+	////////////
+	//  LOGS  //
+	////////////
+
+	logs, err := container.Logs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	//////////////////
+	//  NETWORKING  //
+	//////////////////
+
 	// TODO: cache this?
 	networks, err := container.Manager.NetworkList(ctx, types.NetworkListOptions{
 		Filters: filters.NewArgs(
@@ -262,7 +275,7 @@ func (d *DockerInstanceManager) manageContainer(ctx context.Context, container *
 			}
 		}
 	}
-	return NewInstance(runenv, info.Config.Hostname, network)
+	return NewInstance(runenv, info.Config.Hostname, network, newDockerLogs(logs))
 }
 
 type dockerLink struct {

--- a/pkg/sidecar/docker_logs.go
+++ b/pkg/sidecar/docker_logs.go
@@ -1,0 +1,53 @@
+package sidecar
+
+import (
+	"io"
+
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/hashicorp/go-multierror"
+)
+
+type dockerLogs struct {
+	logs           io.ReadCloser
+	stdout, stderr io.Reader
+	done           chan struct{}
+	err            error
+}
+
+func newDockerLogs(logs io.ReadCloser) *dockerLogs {
+	rstderr, wstderr := io.Pipe()
+	rstdout, wstdout := io.Pipe()
+
+	dl := &dockerLogs{
+		logs:   logs,
+		stdout: rstdout,
+		stderr: rstderr,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		_, dl.err = stdcopy.StdCopy(wstdout, wstderr, logs)
+		close(dl.done)
+	}()
+
+	return dl
+}
+
+func (dl *dockerLogs) Stdout() io.Reader {
+	return dl.stdout
+}
+
+func (dl *dockerLogs) Stderr() io.Reader {
+	return dl.stderr
+}
+
+func (dl *dockerLogs) Close() error {
+	var err *multierror.Error
+	err = multierror.Append(err, dl.logs.Close())
+	err = multierror.Append(err, dl.Wait())
+	return err.ErrorOrNil()
+}
+
+func (dl *dockerLogs) Wait() error {
+	<-dl.done
+	return dl.err
+}

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -102,6 +102,19 @@ func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *doc
 		return nil, nil
 	}
 
+	////////////
+	//  LOGS  //
+	////////////
+
+	logs, err := container.Logs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	//////////////////
+	//  NETWORKING  //
+	//////////////////
+
 	// Initialise CNI config
 	cninet := libcni.NewCNIConfig(filepath.SplitList("/host/opt/cni/bin"), nil)
 
@@ -227,7 +240,7 @@ func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *doc
 		}
 	}
 
-	return NewInstance(runenv, info.Config.Hostname, network)
+	return NewInstance(runenv, info.Config.Hostname, network, newDockerLogs(logs))
 }
 
 type k8sLink struct {

--- a/pkg/sidecar/other.go
+++ b/pkg/sidecar/other.go
@@ -10,6 +10,6 @@ func GetRunners() []string {
 	return nil
 }
 
-func Run(_ string) error {
+func Run(_, _ string) error {
 	return errors.New("the sidecar must be run from within a Linux host")
 }

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -6,9 +6,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/ipfs/testground/pkg/logging"
 	"github.com/ipfs/testground/sdk/sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 var runners = map[string]func() (InstanceManager, error){
@@ -32,7 +36,7 @@ type InstanceManager interface {
 }
 
 // Run runs the sidecar in the given runner environment.
-func Run(runnerName string) error {
+func Run(runnerName string, resultPath string) error {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
@@ -57,68 +61,99 @@ func Run(runnerName string) error {
 			}
 		}()
 
-		err := instance.Network.ConfigureNetwork(ctx, &sync.NetworkConfig{
-			Network: "default",
-			Enable:  true,
-		})
-		if err != nil {
-			return err
-		}
+		g, ctx := errgroup.WithContext(ctx)
 
-		/* TODO: Initialize all networks to the "down" state.
-		for _, n := range instance.Network.ListActive() {
-			instance.Network.ConfigureNetwork(&sync.NetworkConfig{
-				Network: n,
-				Enable:  false,
+		// Network configuration loop.
+		g.Go(func() error {
+			err := instance.Network.ConfigureNetwork(ctx, &sync.NetworkConfig{
+				Network: "default",
+				Enable:  true,
 			})
-		}
-		*/
 
-		// Wait for all the sidecars to enter the "network-initialized" state.
-		const netInitState = "network-initialized"
-		if _, err = instance.Writer.SignalEntry(netInitState); err != nil {
-			return fmt.Errorf("failed to signal network ready: %w", err)
-		}
-		instance.S().Infof("waiting for all networks to be ready")
-		if err := <-instance.Watcher.Barrier(
-			ctx,
-			netInitState,
-			int64(instance.RunEnv.TestInstanceCount),
-		); err != nil {
-			return fmt.Errorf("failed to wait for network ready: %w", err)
-		}
-		instance.S().Infof("all networks ready")
-
-		// Now let the test case tell us how to configure the network.
-		subtree := sync.NetworkSubtree(instance.Hostname)
-		networkChanges := make(chan *sync.NetworkConfig, 16)
-		closeSub, err := instance.Watcher.Subscribe(subtree, networkChanges)
-		if err != nil {
-			return fmt.Errorf("failed to subscribe to network changes: %s", err)
-		}
-		defer func() {
-			if err := closeSub(); err != nil {
-				instance.S().Warnf("failed to close sub: %s", err)
+			if err != nil {
+				return err
 			}
-		}()
 
-		for cfg := range networkChanges {
-			instance.S().Infow("applying network change", "network", cfg)
-			if err := instance.Network.ConfigureNetwork(ctx, cfg); err != nil {
-				return fmt.Errorf("failed to update network %s: %w", cfg.Network, err)
+			// Wait for all the sidecars to enter the "network-initialized" state.
+			const netInitState = "network-initialized"
+			if _, err = instance.Writer.SignalEntry(netInitState); err != nil {
+				return fmt.Errorf("failed to signal network ready: %w", err)
 			}
-			if cfg.State != "" {
-				_, err := instance.Writer.SignalEntry(cfg.State)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to signal network state change %s: %w",
-						cfg.State,
-						err,
-					)
+			instance.S().Infof("waiting for all networks to be ready")
+			if err := <-instance.Watcher.Barrier(
+				ctx,
+				netInitState,
+				int64(instance.RunEnv.TestInstanceCount),
+			); err != nil {
+				return fmt.Errorf("failed to wait for network ready: %w", err)
+			}
+			instance.S().Infof("all networks ready")
+
+			// Now let the test case tell us how to configure the network.
+			subtree := sync.NetworkSubtree(instance.Hostname)
+			networkChanges := make(chan *sync.NetworkConfig, 16)
+			closeSub, err := instance.Watcher.Subscribe(subtree, networkChanges)
+			if err != nil {
+				return fmt.Errorf("failed to subscribe to network changes: %s", err)
+			}
+			defer func() {
+				if err := closeSub(); err != nil {
+					instance.S().Warnf("failed to close sub: %s", err)
+				}
+			}()
+			for cfg := range networkChanges {
+				instance.S().Infow("applying network change", "network", cfg)
+				if err := instance.Network.ConfigureNetwork(ctx, cfg); err != nil {
+					return fmt.Errorf("failed to update network %s: %w", cfg.Network, err)
+				}
+				if cfg.State != "" {
+					_, err := instance.Writer.SignalEntry(cfg.State)
+					if err != nil {
+						return fmt.Errorf(
+							"failed to signal network state change %s: %w",
+							cfg.State,
+							err,
+						)
+					}
 				}
 			}
-		}
+			return nil
+		})
 
-		return nil
+		if resultPath != "" {
+			// Log monitor.
+			g.Go(func() error {
+				path := filepath.Join(
+					resultPath,
+					instance.RunEnv.TestPlan,
+					instance.RunEnv.TestRun,
+					instance.Hostname,
+				)
+				err := os.MkdirAll(path, 0777)
+				if err != nil {
+					return err
+				}
+
+				g.Go(func() error {
+					f, err := os.Create(filepath.Join(path, "stderr.json"))
+					if err != nil {
+						return err
+					}
+					_, err = io.Copy(f, instance.Logs.Stderr())
+					return err
+				})
+
+				g.Go(func() error {
+					f, err := os.Create(filepath.Join(path, "stdout.json"))
+					if err != nil {
+						return err
+					}
+					_, err = io.Copy(f, instance.Logs.Stdout())
+					return err
+				})
+				return nil
+			})
+		}
+		return g.Wait()
 	})
 }

--- a/plans/network/main.go
+++ b/plans/network/main.go
@@ -229,7 +229,7 @@ func run(runenv *runtime.RunEnv) error {
 		}
 		return nil
 	}
-	err = pingPong("200", 200*time.Millisecond, 205*time.Millisecond)
+	err = pingPong("200", 200*time.Millisecond, 210*time.Millisecond)
 	if err != nil {
 		return err
 	}

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -46,6 +46,8 @@ type RunEnv struct {
 	TestBranch string `json:"test_branch,omitempty"`
 	TestTag    string `json:"test_tag,omitempty"`
 
+	TestArtifacts string `json:"test_artifacts,omitempty"`
+
 	TestInstanceCount  int               `json:"test_instance_count"`
 	TestInstanceRole   string            `json:"test_instance_role,omitempty"`
 	TestInstanceParams map[string]string `json:"test_instance_params,omitempty"`
@@ -111,7 +113,7 @@ func (re *RunEnv) Loggers() (*zap.Logger, *zap.SugaredLogger) {
 // initLoggers populates loggers from this RunEnv.
 func (re *RunEnv) initLoggers() {
 	cfg := zap.NewDevelopmentConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zapcore.FatalLevel)
+	cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 
 	if level := os.Getenv("LOG_LEVEL"); level != "" {
 		l := zapcore.Level(0)

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -114,6 +114,7 @@ func (re *RunEnv) Loggers() (*zap.Logger, *zap.SugaredLogger) {
 func (re *RunEnv) initLoggers() {
 	cfg := zap.NewDevelopmentConfig()
 	cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	cfg.Encoding = "json"
 
 	if level := os.Getenv("LOG_LEVEL"); level != "" {
 		l := zapcore.Level(0)


### PR DESCRIPTION
* Mount an assets directory in test containers for persisting assets.
* Use the sidecar to write stderr/stdout to the each test instance's asset directory.

Currently, we put all this in the "work directory" under "results". I.e., `~/.testground/results/$testplan/$runid/$container_hostname/`.

At the moment, this is configured for local docker only. On K8S, we should mount the same S3 bucket on each host then mount that S3 bucket inside the sidecar and each test instance.

Note: I've also removed the log_file option from the docker runner. That's no longer useful given that we store test results.

part of #377