### PR TITLE
feat(plans/dht): log network connect and disconnect events

### DIFF
--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -91,6 +91,24 @@ func NewDHTNode(ctx context.Context, runenv *runtime.RunEnv, opts *SetupOpts) (h
 		return nil, nil, err
 	}
 
+	// Start logging network events.
+	netLogger := runenv.SLogger().With("id", node.ID()).Named("network")
+	node.Network().Notify(&network.NotifyBundle{
+		ConnectedF: func(n network.Network, c network.Conn) {
+			netLogger.Infow(
+				"connect",
+				"peer", c.RemotePeer(),
+				"dir", c.Stat().Direction,
+			)
+		},
+		DisconnectedF: func(n network.Network, c network.Conn) {
+			netLogger.Infow(
+				"disconnect",
+				"peer", c.RemotePeer(),
+			)
+		},
+	})
+
 	dhtOptions := []dhtopts.Option{
 		dhtopts.Datastore(datastore.NewMapDatastore()),
 		dhtopts.BucketSize(opts.BucketSize),


### PR DESCRIPTION
Part of #404. Given this, we should be able to use the network logs to generate a nice visualization.