### PR TITLE
sidecar race with kubernetes and CNI

### DIFF
--- a/infra/k8s/redis-values.yaml
+++ b/infra/k8s/redis-values.yaml
@@ -253,10 +253,10 @@ master:
 
   ## Redis Master resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 100m
+  resources:
+    requests:
+      memory: 2048Mi
+      cpu: 2000m
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/vishvananda/netlink"
@@ -82,6 +83,10 @@ func (d *K8sInstanceManager) Close() error {
 }
 
 func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *dockermanager.Container) (inst *Instance, err error) {
+	// TODO: sidecar is racing to modify container network with CNI and pod getting ready
+	// we should probably adjust this function to be called when a pod is in `1/1 Ready` state, and not just listen on the docker socket
+	time.Sleep(20 * time.Second)
+
 	// Get the state/config of the cluster
 	info, err := container.Inspect(ctx)
 	if err != nil {


### PR DESCRIPTION
This is solving the issue of Kubernetes killing on occasion containers due to it not able to get a pod IP:

```
Jan 24 14:23:19 ip-172-20-43-110 kubelet[18017]: W0124 14:23:19.263257   18017 docker_sandbox.go:394] failed to read pod IP from plugin/docker: networkPlugin cni failed on the status hook for pod "tg-dht-17_default": unexpected address output
Jan 24 14:23:19 ip-172-20-43-110 kubelet[18017]: I0124 14:23:19.266469   18017 kuberuntime_manager.go:454] Sandbox for pod "tg-dht-17_default(a5352449-3888-4da3-95ad-540f02760d7e)" has no IP address. Need to start a new one
```

I assume that `sidecar` has restricted the container network, before the `pod` to which this container belongs had a chance to get to `Ready` state.

Obviously this is a hack and `time.Sleep` is not reliable, but I managed to run 800 `dht/find-peer` plans on 6 worker nodes `c5.2xlarge` (having also modified the `maxPod` limit).

Will see how we can address this properly.