### PR TITLE
Pip install to homedir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pre-commit:
-	python -m pip install pre-commit --upgrade
+	python -m pip install pre-commit --upgrade --user
 	pre-commit install --install-hooks
 
 docker-ipfs-testground:


### PR DESCRIPTION
This causes executable to land in $HOME/.local/bin/
No root user required.