### PR TITLE
Increase retry timeout

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -42,7 +42,7 @@ aws s3api create-bucket \
     --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1
 ```
 
-3. Pick up a cluster name, and set zone and kops state store
+3. Pick up a cluster name, and set zone and kops state store. You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
 
 ```
 export NAME=my-first-cluster-kops.k8s.local
@@ -50,7 +50,7 @@ export KOPS_STATE_STORE=s3://kops-backend-bucket
 export ZONES=eu-central-1a
 ```
 
-4. Generate the cluster spec
+4. Generate the cluster spec. You could reuse it next time you create a cluster.
 
 ```
 kops create cluster \
@@ -183,4 +183,5 @@ Testground is still in very early stage of development. It is possible that it c
 
 - [ ] 3. Alerts (and maybe auto-scaling down) for idle clusters, so that we don't incur costs.
 
-- [ ] 4. We need to decide where Testground is going to publish built docker images - DockerHub? or? This might incur a lot of costs if you build a large image and download it from 100 VMs repeatedly.
+- [X] 4. We need to decide where Testground is going to publish built docker images - DockerHub? or? This might incur a lot of costs if you build a large image and download it from 100 VMs repeatedly.
+Resolution: For now we are using AWS ECR, as clusters are also on AWS.

--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -420,7 +420,7 @@ func Connect(ctx context.Context, runenv *runtime.RunEnv, dht *kaddht.IpfsDHT, t
 		for i := 1; i <= attempts; i++ {
 			runenv.Message("dialling peer %s (attempt %d)", ai.ID, i)
 			select {
-			case <-time.After(time.Duration(rand.Intn(500)+100) * time.Millisecond):
+			case <-time.After(time.Duration(rand.Intn(500)+6000) * time.Millisecond):
 			case <-ctx.Done():
 				return fmt.Errorf("error while dialing peer %v, attempts made: %d: %w", ai.Addrs, i, ctx.Err())
 			}

--- a/plans/dht/test/common.go
+++ b/plans/dht/test/common.go
@@ -420,7 +420,7 @@ func Connect(ctx context.Context, runenv *runtime.RunEnv, dht *kaddht.IpfsDHT, t
 		for i := 1; i <= attempts; i++ {
 			runenv.Message("dialling peer %s (attempt %d)", ai.ID, i)
 			select {
-			case <-time.After(time.Duration(rand.Intn(500)+6000) * time.Millisecond):
+			case <-time.After(time.Duration(rand.Intn(500))*time.Millisecond + 6*time.Second):
 			case <-ctx.Done():
 				return fmt.Errorf("error while dialing peer %v, attempts made: %d: %w", ai.Addrs, i, ctx.Err())
 			}


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/417

With this, I see only up to 2 attempts in the logs, and not 5, so it looks like the 2nd attempt is successful.

However the `dht/find-peers` testplan is still not successful:

```
{"runenv":{"test_plan":"dht","test_case":"find-peers","test_run":"974fd68b-b6ac-4a1b-9b11-04c7a6616bd0","test_seq":0,"test_instance_count":840,"test_instance_params":{"auto_refresh":"\"true\"","bucket_size":"2","n_bootstrap":"1","n_find_peers":"1","random_walk":"\"false\"","timeout_secs":"300"},"test_sidecar":true,"test_network":{"IP":"17.87.0.0","Mask":"//8AAA=="}},"timestamp":1580221453306736283,"result":{"outcome":"aborted","reason":"context deadline exceeded waiting on bootstrap-connected; not enough elements, required: 840, got: 838"}}
```