### PR TITLE
chore: do not fail on negative cov difference

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
         # Commits pushed to master should not make the overall
         # project coverage decrease by more than 5%:
         target: auto
-        threshold: 5%
+        threshold: 100%
     patch:
       default:
         # https://docs.codecov.io/docs/commit-status#section-informational
@@ -22,4 +22,4 @@ coverage:
         # extension:
         # https://github.com/codecov/browser-extension
         target: auto
-        threshold: 5%
+        threshold: 100%


### PR DESCRIPTION
Apparently, the informational flag on Codecov is not working as we expect it to, i.e., not to fail when there are negative changes in the coverage.

My idea is to just change the threshold to 100%. This param is:

> Allow the coverage to drop by X%, and posting a success status.

Closes #321.