### PR TITLE
feat: add test output file path

### DIFF
--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -3,6 +3,10 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ipfs/testground/pkg/api"
 )
 
 // Use consistent IP address ranges for both the data and the control subnet.
@@ -24,4 +28,20 @@ func nextDataNetwork(lenNetworks int) (string, string, error) {
 	gateway := fmt.Sprintf("%d.%d.0.1", a, b)
 
 	return subnet, gateway, nil
+}
+
+func getWorkDir(input *api.RunInput) (string, error) {
+	path := filepath.Join(input.EnvConfig.WorkDir(), "results")
+	err := os.MkdirAll(path, 0777)
+	return path, err
+}
+
+func getRunDir(input *api.RunInput) (string, error) {
+	workDir, err := getWorkDir(input)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(workDir, input.TestPlan.Name, input.RunID)
+	err = os.MkdirAll(path, 0777)
+	return path, err
 }

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -147,8 +147,8 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 	}
 
 	// Ensure the work dir.
-	workDir := filepath.Join(input.EnvConfig.WorkDir(), "results")
-	if err := os.MkdirAll(workDir, 0777); err != nil {
+	workDir, err := getWorkDir(input)
+	if err != nil {
 		return nil, err
 	}
 
@@ -163,9 +163,8 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 		return nil, err
 	}
 
-	// Create the run output directory and write the runenv.
-	runDir := filepath.Join(workDir, input.TestPlan.Name, input.RunID)
-	if err := os.MkdirAll(runDir, 0777); err != nil {
+	runDir, err := getRunDir(input)
+	if err != nil {
 		return nil, err
 	}
 	if f, err := os.Create(filepath.Join(runDir, "env.json")); err == nil {

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -208,8 +208,8 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 				"testground.runid":    input.RunID,
 			},
 		}
-		assetsDir := filepath.Join(runDir, name)
-		err = os.Mkdir(assetsDir, 0777)
+		hostAssetsDir := filepath.Join(runDir, name)
+		err = os.Mkdir(hostAssetsDir, 0777)
 		if err != nil {
 			break
 		}
@@ -217,7 +217,7 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 			NetworkMode: container.NetworkMode(controlNetworkID),
 			Mounts: []mount.Mount{{
 				Type:   mount.TypeBind,
-				Source: assetsDir,
+				Source: hostAssetsDir,
 				Target: runenv.TestAssetsDir,
 			}},
 		}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -209,8 +209,8 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 				"testground.runid":    input.RunID,
 			},
 		}
-		artifactDir := filepath.Join(runDir, name)
-		err = os.Mkdir(artifactDir, 0777)
+		assetsDir := filepath.Join(runDir, name)
+		err = os.Mkdir(assetsDir, 0777)
 		if err != nil {
 			break
 		}
@@ -218,7 +218,7 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 			NetworkMode: container.NetworkMode(controlNetworkID),
 			Mounts: []mount.Mount{{
 				Type:   mount.TypeBind,
-				Source: artifactDir,
+				Source: assetsDir,
 				Target: runenv.TestAssetsDir,
 			}},
 		}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -107,7 +107,7 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 		TestInstanceCount:  input.Instances,
 		TestInstanceParams: input.Parameters,
 		TestSidecar:        true,
-		TestArtifacts:      "/artifacts",
+		TestAssetsDir:      "/artifacts",
 	}
 
 	// Create a docker client.
@@ -219,7 +219,7 @@ func (*LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wr
 			Mounts: []mount.Mount{{
 				Type:   mount.TypeBind,
 				Source: artifactDir,
-				Target: runenv.TestArtifacts,
+				Target: runenv.TestAssetsDir,
 			}},
 		}
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 
 	"github.com/ipfs/testground/pkg/api"
@@ -81,6 +83,12 @@ func (*LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow i
 
 	testcase := plan.TestCases[seq]
 
+	// Create the assets directory
+	assetsDir := filepath.Join(input.EnvConfig.WorkDir(), input.TestPlan.Name, input.RunID, "assets")
+	if err := os.MkdirAll(assetsDir, 0777); err != nil {
+		return nil, err
+	}
+
 	// Build a runenv.
 	runenv := &runtime.RunEnv{
 		TestPlan:           input.TestPlan.Name,
@@ -91,6 +99,7 @@ func (*LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow i
 		TestInstanceParams: input.Parameters,
 		TestSidecar:        false,
 		TestSubnet:         localSubnet,
+		TestAssetsDir:      assetsDir,
 	}
 
 	// Spawn as many instances as the input parameters require.

--- a/sdk/runtime/files.go
+++ b/sdk/runtime/files.go
@@ -60,11 +60,11 @@ func (re *RunEnv) CreateRandomDirectory(directoryPath string, depth uint) (strin
 	return base, nil
 }
 
-// CreateArtifact creates a test artifact.
+// CreateAsset creates a test artifact.
 //
-// Test artifacts will be saved when the test terminates and available for
+// Test assets will be saved when the test terminates and available for
 // further investigation. You can also manually create test
-// artifacts/directories under re.TestAssetsDir.
-func (re *RunEnv) CreateArtifact(name string) (*os.File, error) {
+// assets/directories under re.TestAssetsDir.
+func (re *RunEnv) CreateAsset(name string) (*os.File, error) {
 	return os.Create(filepath.Join(re.TestAssetsDir, name))
 }

--- a/sdk/runtime/files.go
+++ b/sdk/runtime/files.go
@@ -64,7 +64,7 @@ func (re *RunEnv) CreateRandomDirectory(directoryPath string, depth uint) (strin
 //
 // Test artifacts will be saved when the test terminates and available for
 // further investigation. You can also manually create test
-// artifacts/directories under re.TestArtifacts.
+// artifacts/directories under re.TestAssetsDir.
 func (re *RunEnv) CreateArtifact(name string) (*os.File, error) {
-	return os.Create(filepath.Join(re.TestArtifacts, name))
+	return os.Create(filepath.Join(re.TestAssetsDir, name))
 }

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -46,7 +46,7 @@ type RunEnv struct {
 	TestBranch string `json:"test_branch,omitempty"`
 	TestTag    string `json:"test_tag,omitempty"`
 
-	TestArtifacts string `json:"test_artifacts,omitempty"`
+	TestAssetsDir string `json:"test_assets_dir,omitempty"`
 
 	TestInstanceCount  int               `json:"test_instance_count"`
 	TestInstanceRole   string            `json:"test_instance_role,omitempty"`


### PR DESCRIPTION
This finishes two TODOs from #374:

- local:exec runner.
- rename `TestArtifacts` to `TestAssetsDir`.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>