### PR TITLE
Only build Docker logs on linux

### DIFF
--- a/pkg/sidecar/docker_logs.go
+++ b/pkg/sidecar/docker_logs.go
@@ -1,3 +1,5 @@
+//+build linux
+
 package sidecar
 
 import (


### PR DESCRIPTION
`dockerLogs` is a private struct that is only used in the linux host, it's file should be linux build only as is the rest of the sidecar package. Since we have git commit hooks that run the linter this is required to make commits on Windows succeed.

@Stebalien should I enable the linter for the Windows CI to prevent this in the future or is the cost not worth it?