### PR TITLE
stdout and stderr logs from k8s

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -102,7 +102,7 @@ kubectl create secret generic assets-s3-bucket --from-literal=access-key="$ASSET
                                                --from-literal=bucket-name="$ASSETS_BUCKET_NAME"
 ```
 
-8. Install CNI-Genie, Weave and S3 bucket daemonset
+9. Install CNI-Genie, Weave and S3 bucket daemonset
 
 ```
 kubectl apply -f ./infra/k8s/kops-weave/genie-plugin.yaml \
@@ -110,7 +110,7 @@ kubectl apply -f ./infra/k8s/kops-weave/genie-plugin.yaml \
               -f ./infra/k8s/kops-weave/s3bucket.yml
 ```
 
-9. Destroy the cluster when you're done working on it
+10. Destroy the cluster when you're done working on it
 
 ```
 kops delete cluster $NAME --yes

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -262,17 +262,9 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 				if err != nil {
 					return err
 				}
+				defer f.Close()
 
-				err = getPodLogs(client, podName, f)
-				if err != nil {
-					return err
-				}
-
-				err = f.Close()
-				if err != nil {
-					return err
-				}
-				return nil
+				return getPodLogs(client, podName, f)
 			})
 		}
 	}

--- a/plans/chew-datasets/go.mod
+++ b/plans/chew-datasets/go.mod
@@ -3,14 +3,20 @@ module github.com/ipfs/testground/plans/chew-datasets
 go 1.13
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ipfs/go-ipfs v0.4.22-0.20191108103059-ec748a7b5b2f
 	github.com/ipfs/go-ipfs-api v0.0.2
 	github.com/ipfs/go-ipfs-config v0.0.11
 	github.com/ipfs/go-ipfs-files v0.0.6
 	github.com/ipfs/interface-go-ipfs-core v0.2.3
+	github.com/ipfs/testground v0.0.0-20200203172810-d076a151d33c // indirect
 	github.com/ipfs/testground/sdk/iptb v0.0.0-00010101000000-000000000000
-	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000
+	github.com/ipfs/testground/sdk/runtime v0.0.0-20190921111954-a84ff142a5a3
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 )
 
 replace (

--- a/plans/chew-datasets/go.mod
+++ b/plans/chew-datasets/go.mod
@@ -3,20 +3,14 @@ module github.com/ipfs/testground/plans/chew-datasets
 go 1.13
 
 require (
-	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v1.13.1 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ipfs/go-ipfs v0.4.22-0.20191108103059-ec748a7b5b2f
 	github.com/ipfs/go-ipfs-api v0.0.2
 	github.com/ipfs/go-ipfs-config v0.0.11
 	github.com/ipfs/go-ipfs-files v0.0.6
 	github.com/ipfs/interface-go-ipfs-core v0.2.3
-	github.com/ipfs/testground v0.0.0-20200203172810-d076a151d33c // indirect
 	github.com/ipfs/testground/sdk/iptb v0.0.0-00010101000000-000000000000
-	github.com/ipfs/testground/sdk/runtime v0.0.0-20190921111954-a84ff142a5a3
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000
 )
 
 replace (


### PR DESCRIPTION
1. `structured logs / output` ends up at `~/.testground/results` (at the `WorkDir`).
2. `assets/artifacts` end up at `s3://assets-s3-bucket/` and can be merged with the `logs` with:

```
aws s3 cp s3://assets-s3-bucket/<RUN_ID> ~/.testground/results/<RUN_ID> --recursive
```