### PR TITLE
compositions: follow-up fixes

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -7,20 +7,11 @@ import (
 
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
-	"github.com/ipfs/testground/pkg/engine"
 	"github.com/ipfs/testground/pkg/logging"
 
 	"github.com/BurntSushi/toml"
 	"github.com/urfave/cli"
 )
-
-var builders = func() []string {
-	names := make([]string, 0, len(engine.AllBuilders))
-	for _, b := range engine.AllBuilders {
-		names = append(names, b.ID())
-	}
-	return names
-}()
 
 var BuildCommand = cli.Command{
 	Name:  "build",
@@ -49,12 +40,9 @@ var BuildCommand = cli.Command{
 			Action:    buildSingleCmd,
 			ArgsUsage: "[<testplan>]",
 			Flags: []cli.Flag{
-				cli.GenericFlag{
-					Name: "builder, b",
-					Value: &EnumValue{
-						Allowed: builders,
-						Default: "exec:go",
-					},
+				cli.StringFlag{
+					Name:  "builder, b",
+					Usage: "specifies the builder to use; values include: 'docker:go', 'exec:go'",
 				},
 				cli.StringSliceFlag{
 					Name:  "dep, d",
@@ -79,7 +67,7 @@ func buildCompositionCmd(c *cli.Context) (err error) {
 	if _, err = toml.DecodeFile(file, comp); err != nil {
 		return fmt.Errorf("failed to process composition file: %w", err)
 	}
-	if err = comp.Validate(); err != nil {
+	if err = comp.ValidateForBuild(); err != nil {
 		return fmt.Errorf("invalid composition file: %w", err)
 	}
 

--- a/cmd/itest/build_test.go
+++ b/cmd/itest/build_test.go
@@ -7,6 +7,7 @@ import (
 func TestBuildExecGo(t *testing.T) {
 	err := runSingle(t,
 		"build",
+		"single",
 		"placebo",
 		"--builder",
 		"exec:go",
@@ -23,6 +24,7 @@ func TestBuildDockerGo(t *testing.T) {
 	// docker endpoint. I don't think those assumptions stand.
 	err := runSingle(t,
 		"build",
+		"single",
 		"placebo",
 		"--builder",
 		"docker:go",

--- a/cmd/itest/run_test.go
+++ b/cmd/itest/run_test.go
@@ -7,11 +7,14 @@ import (
 func TestAbortedTestShouldFailLocal(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"placebo/abort",
 		"--builder",
 		"exec:go",
 		"--runner",
 		"local:exec",
+		"--instances",
+		"1",
 	)
 
 	if err == nil {
@@ -22,11 +25,14 @@ func TestAbortedTestShouldFailLocal(t *testing.T) {
 func TestAbortedTestShouldFailDocker(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"placebo/abort",
 		"--builder",
 		"docker:go",
 		"--runner",
 		"local:docker",
+		"--instances",
+		"1",
 	)
 
 	if err == nil {
@@ -37,11 +43,14 @@ func TestAbortedTestShouldFailDocker(t *testing.T) {
 func TestIncompatibleRun(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"placebo/ok",
 		"--builder",
 		"exec:go",
 		"--runner",
 		"local:docker",
+		"--instances",
+		"1",
 	)
 
 	if err == nil {
@@ -52,11 +61,14 @@ func TestIncompatibleRun(t *testing.T) {
 func TestCompatibleRunLocal(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"placebo/ok",
 		"--builder",
 		"exec:go",
 		"--runner",
 		"local:exec",
+		"--instances",
+		"1",
 	)
 
 	if err != nil {
@@ -67,11 +79,14 @@ func TestCompatibleRunLocal(t *testing.T) {
 func TestCompatibleRunDocker(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"placebo/ok",
 		"--builder",
 		"docker:go",
 		"--runner",
 		"local:docker",
+		"--instances",
+		"1",
 	)
 
 	if err != nil {

--- a/cmd/itest/sidecar_test.go
+++ b/cmd/itest/sidecar_test.go
@@ -7,11 +7,14 @@ import (
 func TestSidecar(t *testing.T) {
 	err := runSingle(t,
 		"run",
+		"single",
 		"network/ping-pong",
 		"--builder",
 		"docker:go",
 		"--runner",
 		"local:docker",
+		"--instances",
+		"2",
 	)
 
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,24 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
-	"github.com/ipfs/testground/pkg/engine"
 	"github.com/ipfs/testground/pkg/logging"
 
 	"github.com/BurntSushi/toml"
 	"github.com/urfave/cli"
 )
-
-var runners = func() []string {
-	names := make([]string, 0, len(engine.AllRunners))
-	for _, r := range engine.AllRunners {
-		names = append(names, r.ID())
-	}
-	return names
-}()
 
 // RunCommand is the specification of the `run` command.
 var RunCommand = cli.Command{
@@ -56,13 +46,9 @@ var RunCommand = cli.Command{
 			ArgsUsage: "[name]",
 			Flags: append(
 				BuildCommand.Subcommands[1].Flags, // inject all build single command flags.
-				cli.GenericFlag{
-					Name: "runner, r",
-					Value: &EnumValue{
-						Allowed: runners,
-						Default: "local:exec",
-					},
-					Usage: fmt.Sprintf("specifies the runner; options: %s", strings.Join(runners, ", ")),
+				cli.StringFlag{
+					Name:  "runner, r",
+					Usage: "specifies the runner to use; values include: 'local:exec', 'local:docker', 'cluster:k8s'",
 				},
 				cli.StringFlag{
 					Name:  "use-build, ub",
@@ -96,7 +82,7 @@ func runCompositionCmd(c *cli.Context) (err error) {
 		return fmt.Errorf("failed to process composition file: %w", err)
 	}
 
-	if err = comp.Validate(); err != nil {
+	if err = comp.ValidateForRun(); err != nil {
 		return fmt.Errorf("invalid composition file: %w", err)
 	}
 

--- a/docs/COMPOSITIONS.md
+++ b/docs/COMPOSITIONS.md
@@ -3,6 +3,17 @@
 A testground composition is a TOML file that specifies, in a declarative manner,
 all the information needed to run a testground job.
 
+Compositions enable testers to build and schedule test runs comprising instances
+built against different upstream dependencies. Compositions are defined in TOML
+files, and amongst other things, they specify:
+
+* the runner, builder, test plan, and test case.
+* total instance count.
+* groups participating in the run. For each group:
+  - number of instances (as count or percentage).
+  - upstream dependencies to override.
+  - test parameters for that group.
+
 ## File format
 
 The format for the TOML file is as follows:

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -128,8 +128,17 @@ type Dependency struct {
 	Version string `toml:"version" json:"version" validate:"required"`
 }
 
-// Validate validates that this Composition is correct.
-func (c *Composition) Validate() error {
+// ValidateForBuild validates that this Composition is correct for a build.
+func (c *Composition) ValidateForBuild() error {
+	return compositionValidator.StructExcept(c,
+		"Global.Case",
+		"Global.TotalInstances",
+		"Global.Runner",
+	)
+}
+
+// ValidateForRun validates that this Composition is correct for a run.
+func (c *Composition) ValidateForRun() error {
 	// Perform structural validation.
 	if err := compositionValidator.Struct(c); err != nil {
 		return err

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -391,14 +391,14 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 		in.Groups = append(in.Groups, g)
 	}
 
-	_, err = run.Run(ctx, &in, output)
+	out, err := run.Run(ctx, &in, output)
 	if err == nil {
 		logging.S().Infow("run finished successfully", "plan", testplan, "case", testcase, "runner", runner, "instances", in.TotalInstances)
 	} else {
 		logging.S().Infow("run finished in error", "plan", testplan, "case", testcase, "runner", runner, "instances", in.TotalInstances, "error", err)
 	}
 
-	return &api.RunOutput{RunnerID: runner}, nil
+	return out, err
 }
 
 // EnvConfig returns the EnvConfig for this Engine.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -148,7 +148,7 @@ func (e *Engine) ListRunners() map[string]api.Runner {
 }
 
 func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, output io.Writer) ([]*api.BuildOutput, error) {
-	if err := comp.Validate(); err != nil {
+	if err := comp.ValidateForBuild(); err != nil {
 		return nil, fmt.Errorf("invalid composition: %w", err)
 	}
 
@@ -256,7 +256,7 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, output io.W
 }
 
 func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Writer) (*api.RunOutput, error) {
-	if err := comp.Validate(); err != nil {
+	if err := comp.ValidateForRun(); err != nil {
 		return nil, fmt.Errorf("invalid composition: %w", err)
 	}
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -109,6 +109,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		_ = console.Wait()
 	}()
 
+	var total int
 	for _, g := range input.Groups {
 		runenv := template
 		runenv.TestGroupID = g.ID
@@ -118,9 +119,10 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		env := conv.ToOptionsSlice(runenv.ToEnvVars())
 
 		for i := 0; i < g.Instances; i++ {
-			logging.S().Infow("starting test case instance", "plan", name, "group", g.ID, "number", i)
+			total++
+			logging.S().Infow("starting test case instance", "plan", name, "group", g.ID, "number", i, "total", total)
 
-			id := fmt.Sprintf("instance %3d", i)
+			id := fmt.Sprintf("instance %3d", total)
 			cmd := exec.CommandContext(ctx, g.ArtifactPath)
 			stdout, _ := cmd.StdoutPipe()
 			stderr, _ := cmd.StderrPipe()


### PR DESCRIPTION
* Validate compositions appropriately based on context: is it a build or a run?
* Migrate `builder` and `runner` flags to normal string flags. The previous logic leaked, as runners and builders are maintained and operated on the daemon side, and the client should not instantiate an engine.
* Adjust `cmd/itests` to use the `single` variant of build and run commands; also to pass in the instance count.
* Mutex to avoid concurrent initialisations of the `local:docker` runner.

---

Note: `TestSidecar` times out, but it also did in master previous to merging compositions.