### PR TITLE
fix: use the auto-detected local:docker socket location

### DIFF
--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -81,7 +81,7 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output 
 	}
 
 	cliopts := []client.Opt{
-		client.WithHost(client.DefaultDockerHost),
+		client.FromEnv,
 		client.WithAPIVersionNegotiation(),
 	}
 


### PR DESCRIPTION
E.g., this might be set via DOCKER_HOST.

Note: If we're using a TCP socket, we still guess /var/run/docker.sock. In that case, we might be running on another machine. We could probably get smarter about this, but this is likely good enough.