### PR TITLE
fix k8s autoscaling and proper initialisation of all daemonsets

### DIFF
--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -28,8 +28,7 @@ spec:
         - sh
         - -ac
         - >
-          sleep 20 &&
-          export GW=$(ip route | grep cni0 | awk '{print $7}') &&
+          while [ "$GW" = "" ]; do export GW=$(ip route | grep cni0 | awk '{print $7}'); echo "Got GW: $GW"; sleep 5; done;
           echo $GW &&
           ip route &&
           ip route add 100.64.0.0/16 via $GW &&


### PR DESCRIPTION
Fixes https://github.com/ipfs/testground/issues/416

Now the `initContainer` on `sidecar` daemon, won't start until `cni0` is available. `cni0` is created by the first pod on every host, which attaches to the default k8s network (flannel) - in the current setup that would be the `s3bucket` daemon.