### PR TITLE
use shorter runid

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -317,6 +317,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 	if err != nil {
 		return nil, fmt.Errorf("error while generating test run ID: %w", err)
 	}
+	runid := id.String()[24:]
 
 	// This var compiles all configurations to coalesce.
 	//
@@ -361,7 +362,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 	}
 
 	in := api.RunInput{
-		RunID:          id.String(),
+		RunID:          runid,
 		EnvConfig:      *e.envcfg,
 		RunnerConfig:   obj,
 		Directories:    e.envcfg,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -226,7 +226,7 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, output io.W
 			logging.S().Infow("performing build for group", "plan", testplan, "group", grp.ID, "builder", builder)
 
 			in := &api.BuildInput{
-				BuildID:      uuid.New().String(),
+				BuildID:      uuid.New().String()[24:],
 				BuildConfig:  obj,
 				EnvConfig:    *e.envcfg,
 				Directories:  e.envcfg,
@@ -313,11 +313,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 	// the run ID in the state db.
 	//
 	// This Run ID is shared by all groups in the composition.
-	id, err := uuid.NewRandom()
-	if err != nil {
-		return nil, fmt.Errorf("error while generating test run ID: %w", err)
-	}
-	runid := id.String()[24:]
+	runid := uuid.New().String()[24:]
 
 	// This var compiles all configurations to coalesce.
 	//

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -172,7 +172,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 			i := i
 			sem <- struct{}{}
 
-			podName := fmt.Sprintf("%s-%s-%d", jobName, g.ID, i)
+			podName := fmt.Sprintf("%s-%s-%s-%d", jobName, input.RunID, g.ID, i)
 
 			defer func() {
 				if cfg.KeepService {
@@ -219,7 +219,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 				}
 				defer pool.Release(client)
 
-				podName := fmt.Sprintf("%s-%s-%d", jobName, g.ID, i)
+				podName := fmt.Sprintf("%s-%s-%s-%d", jobName, input.RunID, g.ID, i)
 
 				logs := getPodLogs(client, podName)
 


### PR DESCRIPTION
I think it is nicer to use a shorter runid for test plans, because then we don't have gigantic folder name, pod names, etc.

12 characters with an alphabet of 26+10 is enough entropy IMO.

---

Also adding the `RunID` as part of pod name, so that we can run multiple testplans and also use `keep_service=true`.