### PR TITLE
use ipfs/testground:s3fs image

### DIFF
--- a/infra/k8s/kops-weave/s3bucket.yml
+++ b/infra/k8s/kops-weave/s3bucket.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: s3fs
-          image: nonsens3/s3fs
+          image: ipfs/testground:s3fs
           imagePullPolicy: Always
           securityContext:
             privileged: true


### PR DESCRIPTION
I've added an `automated build` to Docker Hub, so this will be rebuilt on every commit to master based on Dockerfile at `infra/k8s/s3fs/`.