### PR TITLE
sidecar installation - wait for redis

### DIFF
--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -32,7 +32,10 @@ spec:
           echo $GW &&
           ip route &&
           ip route add 100.64.0.0/16 via $GW &&
-          ip route || true
+          ip route || true;
+          nslookup redis-headless;
+          while [ $? -ne 0 ]; do echo "redis-headless doesn't resolve."; sleep 5; nslookup redis-headless; done;
+          echo "redis-headless resolved."
       containers:
       - name: testground-sidecar
         image: ipfs/testground:edge


### PR DESCRIPTION
This PR is adding a check requiring redis to be running before we start sidecar.

It makes it possible to install all testground services at the same time without them crashing.