### PR TITLE
improved installation process

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -19,7 +19,7 @@ We use Weave for the `data` plane on Testground - a secondary overlay network th
 
 `kops` uses 100.96.0.0/11 for pod CIDR range, so this is what we use for the `control` network.
 
-Weave by default uses 10.32.0.0/11 as CIDR, so this is the CIDR for the Testground `data` network. The `sidecar` is responsible for setting up the `data` network for every testplan instance.
+We configure Weave to use 16.0.0.0/4 as CIDR (we want to test `libp2p` nodes with IPs in public ranges), so this is the CIDR for the Testground `data` network. The `sidecar` is responsible for setting up the `data` network for every testplan instance.
 
 In order to have two different networks attached to pods in Kubernetes, we run the [CNI-Genie CNI](https://github.com/cni-genie/CNI-Genie).
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -30,7 +30,7 @@ In order to have two different networks attached to pods in Kubernetes, we run t
 2. [AWS CLI](https://aws.amazon.com/cli)
 3. [helm](https://github.com/helm/helm)
 
-## Set up infrastructure with kops
+## Set up cloud credentials, cluster specification and repositories for dependencies
 
 1. [Configure your AWS credentials](https://docs.aws.amazon.com/cli/)
 
@@ -92,7 +92,8 @@ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 
-7. Apply cluster setup and install Testground dependencies
+## Apply the cluster configuration and create cloud resources and install Testground dependencies
+
 ```
 ./install.sh $NAME $CLUSTER_SPEC $PUBKEY $WORKER_NODES
 ```

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+START_TIME=`date +%s`
+
 echo "Creating cluster for Testground..."
 echo
 
@@ -61,3 +63,6 @@ while [ "$RUNNING_SIDECARS" -ne "$WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl
 
 echo "Testground cluster is ready"
 echo
+
+END_TIME=`date +%s`
+echo "Execution time was `expr $END_TIME - $START_TIME` seconds"

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+echo "Creating cluster for Testground..."
+echo
+
+NAME=$1
+CLUSTER_SPEC=$2
+PUBKEY=$3
+WORKER_NODES=$4
+
+echo "Name: $NAME"
+echo "Cluster spec: $CLUSTER_SPEC"
+echo "Public key: $PUBKEY"
+echo "Worker nodes: $WORKER_NODES"
+echo
+
+ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
+ASSETS_ACCESS_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_access_key -)
+ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_secret_key -)
+
+kops create -f $CLUSTER_SPEC
+kops create secret --name $NAME sshpublickey admin -i $PUBKEY
+kops update cluster $NAME --yes
+
+## wait for worker nodes and master to be ready
+echo "Wait for Cluster nodes to be Ready..."
+echo
+READY_NODES=0
+while [ "$READY_NODES" -ne $(($WORKER_NODES + 1)) ]; do READY_NODES=$(kubectl get nodes 2>/dev/null | grep -v NotReady | grep Ready | wc -l || true); echo "Got $READY_NODES ready nodes"; sleep 5; done;
+
+echo "Cluster nodes are Ready"
+echo
+
+echo "Add secret for S3 bucket"
+echo
+kubectl create secret generic assets-s3-bucket --from-literal=access-key="$ASSETS_ACCESS_KEY" \
+                                               --from-literal=secret-key="$ASSETS_SECRET_KEY" \
+                                               --from-literal=bucket-name="$ASSETS_BUCKET_NAME"
+
+
+echo "Install Weave, CNI-Genie, s3bucket DaemonSet, Sidecar Daemonset..."
+echo
+kubectl apply -f ./kops-weave/genie-plugin.yaml \
+              -f ./kops-weave/weave.yml \
+              -f ./kops-weave/s3bucket.yml \
+              -f ./sidecar.yaml
+
+echo "Install Redis..."
+echo
+helm install redis stable/redis --values ./redis-values.yaml
+
+
+echo "Wait for Sidecar to be Ready..."
+echo
+RUNNING_SIDECARS=0
+while [ "$RUNNING_SIDECARS" -ne "$WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl get pods | grep testground-sidecar | grep Running | wc -l || true); echo "Got $RUNNING_SIDECARS running sidecar pods"; sleep 5; done;
+
+echo "Testground cluster is ready"
+echo


### PR DESCRIPTION
This PR is adding an `install.sh` script which goes through all the steps from creating the cluster to the installation of Testground dependencies.

If you have a `cluster.yaml` file, you only have to set the ENV variables (ideally in your .rc file) and have a one-command to start and later destroy the cluster.

---

Also added a note on how to `resize` the cluster in case you figure out that you need more or less machines than originally planned.

---

On my end it takes 6:30min for the cluster to be ready:
```
Testground cluster is ready

Execution time was 383 seconds
```