### PR TITLE
use folder with index name ; sidecar should not logs to /outputs ; toNet should not panic

### DIFF
--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -29,7 +29,7 @@ func (srv *Daemon) runHandler(engine api.Engine) func(w http.ResponseWriter, r *
 
 		out, err := engine.DoRun(r.Context(), &req.Composition, tgw)
 		if err != nil {
-			tgw.WriteError(fmt.Sprintf("engine build error: %s", err))
+			tgw.WriteError(fmt.Sprintf("engine run error: %s", err))
 			return
 		}
 

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -201,7 +201,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 			eg.Go(func() error {
 				defer func() { <-sem }()
 
-				return createPod(ctx, pool, podName, input, runenv, env, k8sConfig.Namespace, g)
+				return createPod(ctx, pool, podName, input, runenv, env, k8sConfig.Namespace, g, i)
 			})
 		}
 	}
@@ -388,7 +388,7 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 	}
 }
 
-func createPod(ctx context.Context, pool *pool, podName string, input *api.RunInput, runenv runtime.RunEnv, env []v1.EnvVar, k8sNamespace string, g api.RunGroup) error {
+func createPod(ctx context.Context, pool *pool, podName string, input *api.RunInput, runenv runtime.RunEnv, env []v1.EnvVar, k8sNamespace string, g api.RunGroup, i int) error {
 	client, err := pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -400,7 +400,7 @@ func createPod(ctx context.Context, pool *pool, podName string, input *api.RunIn
 	sharedVolumeName := "s3-shared"
 
 	mnt := v1.HostPathVolumeSource{
-		Path: fmt.Sprintf("/mnt/%s/%s/%s", input.RunID, g.ID, podName),
+		Path: fmt.Sprintf("/mnt/%s/%s/%d", input.RunID, g.ID, i),
 		Type: &hostpathtype,
 	}
 

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 
+	"github.com/ipfs/testground/pkg/conv"
 	"github.com/ipfs/testground/pkg/dockermanager"
 	"github.com/ipfs/testground/pkg/logging"
 	"github.com/ipfs/testground/sdk/runtime"
@@ -96,6 +97,14 @@ func (d *K8sInstanceManager) manageContainer(ctx context.Context, container *doc
 	if !info.State.Running {
 		return nil, fmt.Errorf("not running")
 	}
+
+	// Remove TEST_OUTPUTS_PATH env var.
+	m, err := conv.ParseKeyValues(info.Config.Env)
+	if err != nil {
+		return nil, err
+	}
+	delete(m, runtime.EnvTestOutputsPath)
+	info.Config.Env = conv.ToOptionsSlice(m)
 
 	// Construct the runtime environment
 	runenv, err := runtime.ParseRunEnv(info.Config.Env)

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -171,6 +171,7 @@ func toBool(s string) bool {
 	return v
 }
 
+// toNet might parse any input, so it is possible to get an error and nil return value
 func toNet(s string) *IPNet {
 	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -172,7 +172,10 @@ func toBool(s string) bool {
 }
 
 func toNet(s string) *IPNet {
-	_, ipnet, _ := net.ParseCIDR(s)
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil
+	}
 	return &IPNet{IPNet: *ipnet}
 }
 


### PR DESCRIPTION
This PR is:
- [x] 1. changing `cluster_k8s` runner to log into directory with the index of the current instance from the group and not the pod name
- [x] 2. fixing bug with parsing empty subnets - sidecar is receiving all kinds of containers, not all are going to need it services
- [x] 3. removing the TEST_OUTPUTS env var from the sidecar config so that it doesn't try to log in /outputs directory