### PR TITLE
release/0.1.0: update go.mod files.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,6 @@ module github.com/ipfs/testground
 go 1.13
 
 replace (
-	github.com/ipfs/testground/sdk/iptb => ./sdk/iptb
-	github.com/ipfs/testground/sdk/runtime => ./sdk/runtime
-	github.com/ipfs/testground/sdk/sync => ./sdk/sync
 	github.com/miekg/dns => github.com/miekg/dns v1.0.14
 
 	// Fix builds on windows.
@@ -25,8 +22,8 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.8
-	github.com/ipfs/testground/sdk/runtime v0.0.0-20190921111954-a84ff142a5a3
-	github.com/ipfs/testground/sdk/sync v0.0.0-20190921111954-a84ff142a5a3
+	github.com/ipfs/testground/sdk/runtime v0.1.0
+	github.com/ipfs/testground/sdk/sync v0.1.0
 	github.com/logrusorgru/aurora v0.0.0-20191017060258-dc85c304c434
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2

--- a/sdk/iptb/go.mod
+++ b/sdk/iptb/go.mod
@@ -10,5 +10,3 @@ require (
 	github.com/ipfs/testground/sdk/runtime v0.1.0
 	github.com/multiformats/go-multiaddr v0.0.4
 )
-
-replace github.com/ipfs/testground/sdk/runtime => ../runtime

--- a/sdk/sync/go.mod
+++ b/sdk/sync/go.mod
@@ -2,13 +2,11 @@ module github.com/ipfs/testground/sdk/sync
 
 go 1.13
 
-replace github.com/ipfs/testground/sdk/runtime => ../runtime
-
 require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.4
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-ipfs-util v0.0.1 // indirect
-	github.com/ipfs/testground v0.0.0-20200121194104-fd53f27ef027
+	github.com/ipfs/testground v0.1.0
 	github.com/ipfs/testground/sdk/runtime v0.1.0
 	github.com/libp2p/go-libp2p-core v0.2.3
 	github.com/multiformats/go-multiaddr v0.1.1


### PR DESCRIPTION
Inter-dependent submodules suck in go. We're hoping for the best here.