### PR TITLE
fix pushing image to remote (aws ecr)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/go-cid v0.0.3 h1:UIAh32wymBpStoe83YCzwVQQ5Oy/H0FdxvUS6DJDzms=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
-github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
-github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/testground v0.1.0/go.mod h1:9obuj1h0ueQuJ5zV5ro69NwU3AHAIw7FXYT1DOj3Ygs=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
 github.com/jbenet/goprocess v0.1.3 h1:YKyIEECS/XvcfHtBzxtjBBbWK+MbvA6dG8ASiqwvr10=

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -288,7 +288,8 @@ func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *clie
 
 	// TODO for some reason, this push is way slower than the equivalent via the
 	// docker CLI. Needs investigation.
-	rc, err := client.ImagePush(ctx, uri, types.ImagePushOptions{
+	log.Infow("pushing image", "tag", tag)
+	rc, err := client.ImagePush(ctx, tag, types.ImagePushOptions{
 		RegistryAuth: aws.ECR.EncodeAuthToken(auth),
 	})
 	if err != nil {


### PR DESCRIPTION
Without this, I get the follow error:
```
Feb  7 12:53:01.542683  INFO    tagging image   {"build_id": "726669436b8b", "tag": "909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht:726669436b8b"}
Feb  7 12:53:01.552942  INFO    pushing image   {"build_id": "726669436b8b", "uri": "909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht"}
The push refers to repository [909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht]
Feb  7 12:53:01.949627  INFO    build failed    {"plan": "dht", "group": "single", "builder": "docker:go", "error": "tag does not exist: 909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht:latest"}
Feb  7 12:53:01.949683  WARN    engine build error: tag does not exist: 909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht:latest   {"ruid": "c00af283"}
```

Not exactly sure how this was working until now. Probably I had `909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht:latest` locally (I did purge all my images a day ago), and somehow we managed to push the currently built tag (in the case above `726669436b8b`.