### PR TITLE
extract outputs configs to toml configuration

### DIFF
--- a/env-example.toml
+++ b/env-example.toml
@@ -30,6 +30,10 @@ docker_tls_ca_cert_path = "/"
 docker_tls_cert_path = "/"
 docker_tls_key_path = "/"
 
+[run_strategies."cluster:k8s"]
+outputs_bucket        = "assets-s3-bucket"
+outputs_bucket_region = "eu-central-1"
+
 [daemon]
 listen = ":8080"
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -49,6 +49,7 @@ aws s3api create-bucket \
 - set number of worker nodes
 - set location for cluster spec to be generated
 - set location of your SSH public key
+- set credentials and locations for `outputs` S3 bucket
 
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
 
@@ -59,6 +60,9 @@ export KOPS_STATE_STORE=s3://kops-backend-bucket
 export WORKER_NODES=4
 export CLUSTER_SPEC=~/cluster.yaml
 export PUBKEY=~/.ssh/id_rsa.pub
+export ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
+export ASSETS_ACCESS_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_access_key -)
+export ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_secret_key -)
 ```
 
 4. Generate the cluster spec. You could reuse it next time you create a cluster.

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o pipefail
-set -o nounset
 
 START_TIME=`date +%s`
 
@@ -20,9 +19,20 @@ echo "Public key: $PUBKEY"
 echo "Worker nodes: $WORKER_NODES"
 echo
 
-ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
-ASSETS_ACCESS_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_access_key -)
-ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_secret_key -)
+if [[ -z ${ASSETS_ACCESS_KEY} ]]; then
+  echo "ASSETS_ACCESS_KEY is not set. Make sure you set credentials and location for S3 outputs bucket."
+  exit 1
+fi
+
+if [[ -z ${ASSETS_SECRET_KEY} ]]; then
+  echo "ASSETS_SECRET_KEY is not set. Make sure you set credentials and location for S3 outputs bucket."
+  exit 1
+fi
+
+if [[ -z ${ASSETS_BUCKET_NAME} ]]; then
+  echo "ASSETS_BUCKET_NAME is not set. Make sure you set credentials and location for S3 outputs bucket."
+  exit 1
+fi
 
 kops create -f $CLUSTER_SPEC
 kops create secret --name $NAME sshpublickey admin -i $PUBKEY

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -89,4 +89,8 @@ type CollectionInput struct {
 	EnvConfig config.EnvConfig
 	RunID     string
 	RunnerID  string
+
+	// RunnerConfig is the configuration of the runner sourced from the test
+	// plan manifest, coalesced with any user-provided overrides.
+	RunnerConfig interface{}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -326,21 +326,21 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 	//
 	var cfg config.CoalescedConfig
 
-	// Add the base configuration of the build strategy (point 3 above).
+	// Add the base configuration of the run strategy (point 3 above).
 	if c, ok := plan.RunStrategies[runner]; !ok {
 		return nil, fmt.Errorf("test plan does not support builder: %s", builder)
 	} else {
 		cfg = cfg.Append(c)
 	}
 
-	// 2. Get the env config for the builder.
+	// 2. Get the env config for the runner.
 	cfg = cfg.Append(e.envcfg.RunStrategies[runner])
 
 	// 1. Get overrides from the CLI.
 	cfg = cfg.Append(comp.Global.RunConfig)
 
 	// Coalesce all configurations and deserialise into the config type
-	// mandated by the builder.
+	// mandated by the runner.
 	obj, err := cfg.CoalesceIntoType(run.ConfigType())
 	if err != nil {
 		return nil, fmt.Errorf("error while coalescing configuration values: %w", err)
@@ -404,10 +404,23 @@ func (e *Engine) DoCollectOutputs(ctx context.Context, runner string, runID stri
 		return fmt.Errorf("unknown runner: %s", runner)
 	}
 
+	var cfg config.CoalescedConfig
+
+	// Get the env config for the runner.
+	cfg = cfg.Append(e.envcfg.RunStrategies[runner])
+
+	// Coalesce all configurations and deserialise into the config type
+	// mandated by the builder.
+	obj, err := cfg.CoalesceIntoType(run.ConfigType())
+	if err != nil {
+		return fmt.Errorf("error while coalescing configuration values: %w", err)
+	}
+
 	input := &api.CollectionInput{
-		RunnerID:  runner,
-		RunID:     runID,
-		EnvConfig: *e.envcfg,
+		RunnerID:     runner,
+		RunID:        runID,
+		EnvConfig:    *e.envcfg,
+		RunnerConfig: obj,
 	}
 
 	return run.CollectOutputs(ctx, input, w)


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/480

---

I think based on the new docs, it should be mostly clear to folks outside PL that they have to provide credentials for an S3 bucket, if they want to create a Kubernetes environment.