### PR TITLE
feat: distinguish between runenv and run params

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -116,7 +116,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 		return nil, fmt.Errorf("invalid test case seq %d for plan %s", input.Seq, input.TestPlan.Name)
 	}
 
-	template := runtime.RunEnv{
+	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          input.TestPlan.TestCases[input.Seq].Name,
 		TestRun:           input.RunID,
@@ -388,7 +388,7 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 	}
 }
 
-func createPod(ctx context.Context, pool *pool, podName string, input *api.RunInput, runenv runtime.RunEnv, env []v1.EnvVar, k8sNamespace string, g api.RunGroup, i int) error {
+func createPod(ctx context.Context, pool *pool, podName string, input *api.RunInput, runenv runtime.RunParams, env []v1.EnvVar, k8sNamespace string, g api.RunGroup, i int) error {
 	client, err := pool.Acquire(ctx)
 	if err != nil {
 		return err

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -91,7 +91,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 	)
 
 	// Build a runenv.
-	template := runtime.RunEnv{
+	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          testcase.Name,
 		TestRun:           input.RunID,

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -136,7 +136,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow io.
 	r.setupLk.Unlock()
 
 	// Build a template runenv.
-	template := runtime.RunEnv{
+	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          testcase.Name,
 		TestRun:           input.RunID,
@@ -345,7 +345,7 @@ func ensureControlNetwork(ctx context.Context, cli *client.Client, log *zap.Suga
 	)
 }
 
-func newDataNetwork(ctx context.Context, cli *client.Client, log *zap.SugaredLogger, env *runtime.RunEnv, name string) (id string, subnet *net.IPNet, err error) {
+func newDataNetwork(ctx context.Context, cli *client.Client, log *zap.SugaredLogger, env *runtime.RunParams, name string) (id string, subnet *net.IPNet, err error) {
 	// Find a free network.
 	networks, err := cli.NetworkList(ctx, types.NetworkListOptions{
 		Filters: filters.NewArgs(

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -97,7 +97,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 	r.setupLk.Unlock()
 
 	// Build a template runenv.
-	template := runtime.RunEnv{
+	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          input.TestPlan.TestCases[seq].Name,
 		TestRun:           input.RunID,

--- a/sdk/runtime/logger.go
+++ b/sdk/runtime/logger.go
@@ -9,14 +9,14 @@ import (
 )
 
 type logger struct {
-	runenv *RunEnv
+	runenv *RunParams
 
 	// TODO: we'll want different kinds of loggers.
 	logger  *zap.Logger
 	slogger *zap.SugaredLogger
 }
 
-func newLogger(runenv *RunEnv) *logger {
+func newLogger(runenv *RunParams) *logger {
 	l := &logger{runenv: runenv}
 	l.init()
 	return l

--- a/sdk/runtime/output.go
+++ b/sdk/runtime/output.go
@@ -31,7 +31,7 @@ type Event struct {
 	Stacktrace string       `json:"stacktrace,omitempty"`
 	Message    string       `json:"message,omitempty"`
 	Metric     *MetricValue `json:"metric,omitempty"`
-	Runenv     *RunEnv      `json:"runenv,omitempty"`
+	Runenv     *RunParams   `json:"runenv,omitempty"`
 }
 
 type MetricDefinition struct {
@@ -85,7 +85,7 @@ func (m MetricValue) MarshalLogObject(oe zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func (r RunEnv) MarshalLogObject(oe zapcore.ObjectEncoder) error {
+func (r *RunParams) MarshalLogObject(oe zapcore.ObjectEncoder) error {
 	oe.AddString("plan", r.TestPlan)
 	oe.AddString("case", r.TestCase)
 	oe.AddInt("seq", r.TestCaseSeq)

--- a/sdk/sync/redis_test.go
+++ b/sdk/sync/redis_test.go
@@ -363,7 +363,7 @@ func randomRunEnv() *runtime.RunEnv {
 
 	_, subnet, _ := net.ParseCIDR("127.1.0.1/16")
 
-	return &runtime.RunEnv{
+	return runtime.NewRunEnv(runtime.RunParams{
 		TestPlan:           fmt.Sprintf("testplan-%d", rand.Uint32()),
 		TestSidecar:        false,
 		TestCase:           fmt.Sprintf("testcase-%d", rand.Uint32()),
@@ -375,5 +375,5 @@ func randomRunEnv() *runtime.RunEnv {
 		TestInstanceCount:  int(1 + (rand.Uint32() % 999)),
 		TestInstanceRole:   "",
 		TestInstanceParams: make(map[string]string),
-	}
+	})
 }


### PR DESCRIPTION
The RunEnv is for the testcase and needs an initialized logger, etc. The run params are just data.

This prevents us from, e.g., calling functions that try to access uninitialized fields. This _also_ lets test cases (e.g., the redis test cases) safely construct fully initialized run environments.