### PR TITLE
fix: remove a runenv hack in the sidecar

### DIFF
--- a/pkg/sidecar/docker_instance.go
+++ b/pkg/sidecar/docker_instance.go
@@ -8,8 +8,6 @@ import (
 	"net"
 	"os"
 
-	"github.com/ipfs/testground/pkg/conv"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -143,24 +141,20 @@ func (d *DockerInstanceManager) manageContainer(ctx context.Context, container *
 		return nil, fmt.Errorf("not running")
 	}
 
-	// Remove TEST_OUTPUTS_PATH env var.
-	m, err := conv.ParseKeyValues(info.Config.Env)
-	if err != nil {
-		return nil, err
-	}
-	delete(m, runtime.EnvTestOutputsPath)
-	info.Config.Env = conv.ToOptionsSlice(m)
-
 	// Construct the runtime environment
-	runenv, err := runtime.ParseRunEnv(info.Config.Env)
+	params, err := runtime.ParseRunParams(info.Config.Env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse run environment: %w", err)
 	}
 
 	// Not using the sidecar, ignore this container.
-	if !runenv.TestSidecar {
+	if !params.TestSidecar {
 		return nil, nil
 	}
+
+	// Remove the TestOutputsPath. We can't store anything from the sidecar.
+	params.TestOutputsPath = ""
+	runenv := runtime.NewRunEnv(*params)
 
 	//////////////////
 	//  NETWORKING  //

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -200,14 +200,14 @@ func CurrentRunEnv() *RunEnv {
 	return re
 }
 
-// ParseRunEnv parses a list of environment variables into a RunEnv.
-func ParseRunEnv(env []string) (*RunEnv, error) {
+// ParseRunParams parses a list of environment variables into a RunParams.
+func ParseRunParams(env []string) (*RunParams, error) {
 	m, err := ParseKeyValues(env)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewRunEnv(RunParams{
+	return &RunParams{
 		TestSidecar:            toBool(m[EnvTestSidecar]),
 		TestPlan:               m[EnvTestPlan],
 		TestCase:               m[EnvTestCase],
@@ -223,7 +223,17 @@ func ParseRunEnv(env []string) (*RunEnv, error) {
 		TestGroupID:            m[EnvTestGroupID],
 		TestGroupInstanceCount: toInt(m[EnvTestGroupInstanceCount]),
 		TestOutputsPath:        m[EnvTestOutputsPath],
-	}), nil
+	}, nil
+}
+
+// ParseRunEnv parses a list of environment variables into a RunEnv.
+func ParseRunEnv(env []string) (*RunEnv, error) {
+	p, err := ParseRunParams(env)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRunEnv(*p), nil
 }
 
 // IsParamSet checks if a certain parameter is set.


### PR DESCRIPTION
Instead of parsing the environment, modifying it, then re-serializing it; parse it without constructing a runenv, modify it, then construct a runenv.

fixes https://github.com/ipfs/testground/pull/502#pullrequestreview-355481906