### PR TITLE
testground clean-up / reset script

### DIFF
--- a/infra/k8s/clean.sh
+++ b/infra/k8s/clean.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+START_TIME=`date +%s`
+
+echo "Resetting Testground environment..."
+echo
+
+kubectl delete pods -l app=testground --force --grace-period=0
+kubectl delete pods -l name=testground-sidecar --force --grace-period=0
+echo
+
+sleep 5
+
+echo "Wait for Sidecar to be Ready..."
+echo
+WORKER_NODES=$(($(kubectl get nodes | grep -v NotReady | grep Ready | wc -l) - 1))
+RUNNING_SIDECARS=0
+while [ "$RUNNING_SIDECARS" -ne "$WORKER_NODES" ]; do RUNNING_SIDECARS=$(kubectl get pods | grep testground-sidecar | grep Running | wc -l || true); echo "Got $RUNNING_SIDECARS running sidecar pods"; sleep 5; done;
+
+echo "Testground cluster is ready"
+echo
+
+END_TIME=`date +%s`
+echo "Clean up time was `expr $END_TIME - $START_TIME` seconds"

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -408,6 +408,7 @@ func createPod(ctx context.Context, pool *pool, podName string, input *api.RunIn
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
 			Labels: map[string]string{
+				"app":                 "testground",
 				"testground.plan":     input.TestPlan.Name,
 				"testground.testcase": runenv.TestCase,
 				"testground.run_id":   input.RunID,


### PR DESCRIPTION
We've spoken that it'd be nice to have a script that resets the Testground environment, so here is an initial attempt at it.

This is removing all pods created by Testground, and restarting Sidecar.

I don't think we have to restart Redis or s3bucket for now, as we've never seen them fail for now.