### PR TITLE
max allowed pods check in cluster_k8s.go

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -49,6 +49,11 @@ const (
 	redisCPUs = 2.0
 	// number of CPUs allocated to each Sidecar. should be same as what is set in sidecar.yaml
 	sidecarCPUs = 0.2
+
+	// utilisation is how many CPUs from the remainder shall we allocate to Testground
+	// note that there are other services running on the Kubernetes cluster such as
+	// api proxy, kubedns, s3bucket, etc.
+	utilisation = 0.8
 )
 
 var (
@@ -508,7 +513,7 @@ func maxPods(pool *pool, podResourceCPU resource.Quantity) (int, error) {
 
 	totalCPUs := nodes * int(nodeCPUs)
 	availableCPUs := float64(totalCPUs) - redisCPUs - float64(nodes)*sidecarCPUs
-	podsCPUs := availableCPUs * 8 / 10 // we use only 80% of CPU of nodes for Testground pods
+	podsCPUs := availableCPUs * utilisation
 	pods := int(math.Round(podsCPUs/podCPU - 0.5))
 
 	return pods, nil

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -44,6 +44,11 @@ var (
 
 const (
 	defaultK8sNetworkAnnotation = "flannel"
+
+	// number of CPUs allocated to Redis. should be same as what is set in redis-values.yaml
+	redisCPUs = 2.0
+	// number of CPUs allocated to each Sidecar. should be same as what is set in sidecar.yaml
+	sidecarCPUs = 0.2
 )
 
 var (
@@ -480,8 +485,6 @@ func (fw FakeWriterAt) WriteAt(p []byte, offset int64) (n int, err error) {
 // maxPods returns the max allowed pods for the current cluster size
 // at the moment we are CPU bound, so this is based only on rough estimation of available CPUs
 func maxPods(pool *pool, podResourceCPU resource.Quantity) (int, error) {
-	redisCPUs := 2.0   // set in redis-values.yaml
-	sidecarCPUs := 0.2 // set in sidecar.yaml
 	podCPU, err := strconv.ParseFloat(podResourceCPU.AsDec().String(), 64)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
A simple check before we try to schedule pods to Kubernetes to make sure we have enough resources.

If we don't do that and a user requests 1000 pods, and has for example only 3-4 workers, then pods would go into `Pending` state, and wait for available resources, which will never come as we currently don't have auto-scaling.

---

Fixes: https://github.com/ipfs/testground/issues/498

---

TODO:
- [x] parse CPU value from config, rather than have it hardcoded