### PR TITLE
Example cluster.yaml

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -68,9 +68,10 @@ aws s3api create-bucket \
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
 
 ```
-export KOPS_STATE_STORE=s3://kops-backend-bucket
+export NAME=<desired kubernetes cluster name>
+export KOPS_STATE_STORE=s3://<kops state s3 bucket>
+export ZONE=<aws region>
 export WORKER_NODES=4
-export CLUSTER_SPEC=~/cluster.yaml
 export PUBKEY=~/.ssh/testground_rsa.pub
 
 # details for S3 bucket to be used for assets
@@ -92,7 +93,7 @@ helm repo update
 ## Install the kuberntes cluster
 
 ```
-./install.sh <cluster name> <aws zone> <template> <ssh public key> <number of worker nodes>
+./install.sh  <template file>
 ```
 
 for example, to create a monitored cluster in eu-central-1a with five kubernetes workers:

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -212,6 +212,24 @@ kubectl get pods -o wide
 kubectl logs <pod-id, e.g. tg-dht-c95b5>
 ```
 
+5. Check on the monitoring infrastructure (it runs in the monitoring namespace)
+```
+kubectl get pods --namespace monitoring
+```
+
+6. Get access to teh redis shell
+```
+kubectl port-forward svc/redis-master 6379:6379 &
+redis-cli -h localhost -p 6379
+```
+
+7. Get access to the kubernetes dashboard 
+```
+kubectl proxy
+```
+and then, direct your browser to `http://localhost:8001/ui`
+
+
 
 ## Use a Kubernetes context for another cluster
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -68,8 +68,6 @@ aws s3api create-bucket \
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
 
 ```
-export NAME=my-first-cluster-kops.k8s.local
-export ZONES=eu-central-1a
 export KOPS_STATE_STORE=s3://kops-backend-bucket
 export WORKER_NODES=4
 export CLUSTER_SPEC=~/cluster.yaml
@@ -84,41 +82,22 @@ export ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_se
 export ASSETS_S3_ENDPOINT=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_s3_endpoint -)
 ```
 
-5. Generate the cluster spec. You could reuse it next time you create a cluster.
-
-```
-kops create cluster \
-  --zones $ZONES \
-  --master-zones $ZONES \
-  --master-size c5.2xlarge \
-  --node-size c5.2xlarge \
-  --node-count $WORKER_NODES \
-  --networking flannel \
-  --name $NAME \
-  --dry-run \
-  -o yaml > $CLUSTER_SPEC
-```
-
-6. Update `kubelet` section in spec with:
-```
-  kubelet:
-    anonymousAuth: false
-    maxPods: 200
-    allowedUnsafeSysctls:
-    - net.core.somaxconn
-```
-
-7. Set up Helm and add the `stable` Helm Charts repository
+5. Set up Helm and add the `stable` Helm Charts repository
 
 ```
 helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 
-## Apply the cluster configuration and create cloud resources and install Testground dependencies
+## Install the kuberntes cluster
 
 ```
-./install.sh $NAME $CLUSTER_SPEC $PUBKEY $WORKER_NODES
+./install.sh <cluster name> <aws zone> <template> <ssh public key> <number of worker nodes>
+```
+
+for example, to create a monitored cluster in eu-central-1a with five kubernetes workers:
+```
+./install.sh test.k8s.local eu-central-1a ./cluster.yaml.example_with_monitoring ~/.ssh/id_rsa.pub 5
 ```
 
 

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -9,7 +9,8 @@ spec:
   - manifest: prometheus-operator
   - manifest: kubernetes-dashboard
   api:
-    dns: {}
+    loadBalancer:
+      type: Public
   authorization:
     rbac: {}
   channel: stable

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -15,17 +15,17 @@ spec:
     rbac: {}
   channel: stable
   cloudProvider: aws
-  configBase: s3://${ASSETS_BUCKET_NAME}/${NAME}
+  configBase: ${KOPS_STATE_STORE}/${NAME}
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: master-eu-central-1a
+    - instanceGroup: master-${ZONE}
       name: a
     memoryRequest: 100Mi
     name: main
   - cpuRequest: 100m
     etcdMembers:
-    - instanceGroup: master-eu-central-1a
+    - instanceGroup: master-${ZONE}
       name: a
     memoryRequest: 100Mi
     name: events
@@ -51,9 +51,9 @@ spec:
   - 0.0.0.0/0
   subnets:
   - cidr: 172.20.32.0/19
-    name: eu-central-1a
+    name: ${ZONE}
     type: Public
-    zone: eu-central-1a
+    zone: ${ZONE}
   topology:
     dns:
       type: Public
@@ -68,17 +68,17 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${NAME}
-  name: master-eu-central-1a
+  name: master-${ZONE}
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: 1
   minSize: 1
   nodeLabels:
-    kops.k8s.io/instancegroup: master-eu-central-1a
+    kops.k8s.io/instancegroup: master-${ZONE}
   role: Master
   subnets:
-  - eu-central-1a
+  - ${ZONE}
 
 ---
 
@@ -98,4 +98,4 @@ spec:
     kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
-  - eu-central-1a
+  - ${ZONE}

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -1,0 +1,108 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: null
+  name: my-first-cluster-kops.k8s.local
+spec:
+  addons:
+  - manifest: metrics-server
+  - manifest: prometheus-operator
+  - manifest: kubernetes-dashboard
+  api:
+    dns: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: s3://kops-backend-bucket/my-first-cluster-kops.k8s.local
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-eu-central-1a
+      name: a
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-eu-central-1a
+      name: a
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubeAPIServer:
+    runtimeConfig:
+      autoscaling/v2beta1: "true"
+  kubeControllerManager:
+    horizontalPodAutoscalerUseRestClients: true
+  kubelet:
+    anonymousAuth: false
+    authenticationTokenWebhook: true
+    authorizationMode: Webhook
+    enableCustomMetrics: true
+    maxPods: 200
+    allowedUnsafeSysctls:
+      - net.core.somaxconn
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.15.7
+  masterInternalName: api.internal.my-first-cluster-kops.k8s.local
+  masterPublicName: api.my-first-cluster-kops.k8s.local
+  networkCIDR: 172.20.0.0/16
+  networking:
+    flannel:
+      backend: vxlan
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: eu-central-1a
+    type: Public
+    zone: eu-central-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: my-first-cluster-kops.k8s.local
+  name: master-eu-central-1a
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-eu-central-1a
+  role: Master
+  subnets:
+  - eu-central-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: my-first-cluster-kops-k8s.local
+  name: nodes
+spec:
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
+  machineType: t2.medium
+  maxSize: 8
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes
+  role: Node
+  subnets:
+  - eu-central-1a

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -71,7 +71,7 @@ metadata:
   name: master-eu-central-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: m3.medium
+  machineType: c5.2xlarge
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -91,7 +91,7 @@ metadata:
   name: nodes
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: t2.medium
+  machineType: c5.2xlarge
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}
   nodeLabels:

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -32,22 +32,14 @@ spec:
   iam:
     allowContainerRegistry: true
     legacy: false
-  kubeAPIServer:
-    runtimeConfig:
-      autoscaling/v2beta1: "true"
-  kubeControllerManager:
-    horizontalPodAutoscalerUseRestClients: true
   kubelet:
     anonymousAuth: false
-    authenticationTokenWebhook: true
-    authorizationMode: Webhook
-    enableCustomMetrics: true
     maxPods: 200
     allowedUnsafeSysctls:
       - net.core.somaxconn
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.15.7
+  kubernetesVersion: 1.15.9
   masterInternalName: api.internal.${NAME}
   masterPublicName: api.${NAME}
   networkCIDR: 172.20.0.0/16
@@ -78,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: ${NAME}
   name: master-eu-central-1a
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -98,7 +90,7 @@ metadata:
     kops.k8s.io/cluster: ${NAME}
   name: nodes
 spec:
-  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
+  image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: t2.medium
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}

--- a/infra/k8s/cluster.yaml.example_with_monitoring
+++ b/infra/k8s/cluster.yaml.example_with_monitoring
@@ -2,7 +2,7 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null
-  name: my-first-cluster-kops.k8s.local
+  name: ${NAME}
 spec:
   addons:
   - manifest: metrics-server
@@ -14,7 +14,7 @@ spec:
     rbac: {}
   channel: stable
   cloudProvider: aws
-  configBase: s3://kops-backend-bucket/my-first-cluster-kops.k8s.local
+  configBase: s3://${ASSETS_BUCKET_NAME}/${NAME}
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
@@ -47,8 +47,8 @@ spec:
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.15.7
-  masterInternalName: api.internal.my-first-cluster-kops.k8s.local
-  masterPublicName: api.my-first-cluster-kops.k8s.local
+  masterInternalName: api.internal.${NAME}
+  masterPublicName: api.${NAME}
   networkCIDR: 172.20.0.0/16
   networking:
     flannel:
@@ -74,7 +74,7 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: my-first-cluster-kops.k8s.local
+    kops.k8s.io/cluster: ${NAME}
   name: master-eu-central-1a
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
@@ -94,13 +94,13 @@ kind: InstanceGroup
 metadata:
   creationTimestamp: null
   labels:
-    kops.k8s.io/cluster: my-first-cluster-kops-k8s.local
+    kops.k8s.io/cluster: ${NAME}
   name: nodes
 spec:
   image: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2019-09-26
   machineType: t2.medium
-  maxSize: 8
-  minSize: 1
+  maxSize: ${WORKER_NODES}
+  minSize: ${WORKER_NODES}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   role: Node

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -8,13 +8,9 @@ START_TIME=`date +%s`
 echo "Creating cluster for Testground..."
 echo
 
-NAME=$1
-CLUSTER_SPEC=$2
-PUBKEY=$3
-WORKER_NODES=$4
+CLUSTER_SPEC_TEMPLATE=$1
 
 echo "Name: $NAME"
-echo "Cluster spec: $CLUSTER_SPEC"
 echo "Public key: $PUBKEY"
 echo "Worker nodes: $WORKER_NODES"
 echo
@@ -38,6 +34,24 @@ if [[ -z ${ASSETS_S3_ENDPOINT} ]]; then
   echo "ASSETS_S3_ENDPOINT is not set. Make sure you set credentials and location for S3 outputs bucket."
   exit 1
 fi
+
+CLUSTER_SPEC=$(mktemp)
+envsubst <$CLUSTER_SPEC_TEMPLATE >$CLUSTER_SPEC
+cat $CLUSTER_SPEC
+
+# Verify with the user before continuing.
+echo
+echo "The output above is the cluster I will create for you."
+echo -n "Does this look about right to you? [y/n]: "
+read response
+
+if [ "$response" != "y" ]
+then
+	echo "Canceling ."
+	exit 2
+fi
+
+# The remainder of this script creates the cluster using the generated template
 
 kops create -f $CLUSTER_SPEC
 kops create secret --name $NAME sshpublickey admin -i $PUBKEY


### PR DESCRIPTION
This is a cluster.yaml which has been edited to enable cluster monitoring with Prometheus

This might fix: https://github.com/ipfs/testground/issues/228

The idea here is to include a cluster.yaml rather than generating it with kops create and making small edits, as currently prescribed in the README. This version includes edits necessary to add host monitoring and enables testground users to observe how the cluster nodes are performing.