### PR TITLE
aws ecr repo should probably be unique across regions

### DIFF
--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -269,8 +269,8 @@ func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *clie
 		return err
 	}
 
-	// AWS ECR repository name is testground-<plan_name>.
-	repo := fmt.Sprintf("testground-%s", in.TestPlan.Name)
+	// AWS ECR repository name is testground-<region>-<plan_name>.
+	repo := fmt.Sprintf("testground-%s-%s", in.EnvConfig.AWS.Region, in.TestPlan.Name)
 
 	// Ensure the repo exists, or create it. Get the full URI to the repo, so we
 	// can tag images.


### PR DESCRIPTION
Adin reported the following failure:

```
Feb 12 11:01:41.601217  INFO    build succeeded {"plan": "dht", "group": "balsa", "builder": "docker:go", "artifact": "909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-dht:708f550fefe8"}
Feb 12 11:01:41.603198  WARN    engine build error: RepositoryAlreadyExistsException: The repository with name 'testground-dht' already exists in the registry with id '909427826938'     {"ruid": "1f1fce89"}
```

It looks like AWS ECR is complaining that a repo already exists in the registry 909427826938 - now this is a bit ambigious, as we have this registry currently in at least 2 regions:

1. `909427826938.dkr.ecr.us-east-1.amazonaws.com/testground-dht`
2. `909427826938.dkr.ecr.eu-central-1.amazonaws.com/testground-dht`

If there is indeed a problem with having the same repo in a given registry at multiple regions, then I would have expected for 1. to never be created. (2. was there first).

---

This PR is adding a region name as part of the repo, so that we differentiate between an AWS ECR repo in one region and another, and not rely on AWS to do that for us. From the AWS ECR FAQ:

```
Q: Does Amazon ECR replicate images across regions?
No. Amazon ECR is designed to give you flexibility in where you store and how you deploy your images. You can create deployment pipelines that build images, push them to Amazon ECR in selected regions, and then deploy the images to your Docker cluster.
```