### PR TITLE
--collect and --collect-file flags

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,9 +38,13 @@ var RunCommand = cli.Command{
 					Name:  "ignore-artifacts, i",
 					Usage: "Ignores any build artifacts present in the composition file.",
 				},
-				cli.StringFlag{
-					Name:  "collect-into, o",
+				cli.BoolFlag{
+					Name:  "collect",
 					Usage: "Collect assets at the end of the run phase.",
+				},
+				cli.StringFlag{
+					Name:  "collect-file, o",
+					Usage: "Destination for the assets if --collect is set",
 				},
 			},
 		},
@@ -179,10 +183,15 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 
 	logging.S().Infof("finished run with ID: %s", rout.RunID)
 
-	// if the `collect-into` flag is not set, we are done, just return
-	collectInto := c.String("collect-into")
-	if collectInto == "" {
+	// if the `collect` flag is not set, we are done, just return
+	collect := c.Bool("collect")
+	if !collect {
 		return nil
+	}
+
+	collectFile := c.String("collect-file")
+	if collectFile == "" {
+		collectFile = fmt.Sprintf("%s.zip", rout.RunID)
 	}
 
 	or := &client.OutputsRequest{
@@ -192,7 +201,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 
 	rc, err := cl.CollectOutputs(ctx, or)
 
-	file, err := os.Create(collectInto)
+	file, err := os.Create(collectFile)
 	if err != nil {
 		if err == context.Canceled {
 			return fmt.Errorf("interrupted")
@@ -206,6 +215,6 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 		return err
 	}
 
-	logging.S().Infof("created file: %s", collectInto)
+	logging.S().Infof("created file: %s", collectFile)
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/520

---

Cross posting from another PR:

It currently takes almost 2 min to download assets with `--collect` for run `9ccc44f28b15` (~2k small files), whereas downloading with `aws s3 cp --recursive` takes 10 seconds.

Maybe we should refactor this to first download and then zip, rather than be forced to download sequentially. WDYT ?