### PR TITLE
extract S3_ENDPOINT in var, so that we can change region for bucket

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -63,6 +63,7 @@ export PUBKEY=~/.ssh/id_rsa.pub
 export ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
 export ASSETS_ACCESS_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_access_key -)
 export ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_secret_key -)
+export ASSETS_S3_ENDPOINT=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_s3_endpoint -)
 ```
 
 4. Generate the cluster spec. You could reuse it next time you create a cluster.

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -60,9 +60,13 @@ export KOPS_STATE_STORE=s3://kops-backend-bucket
 export WORKER_NODES=4
 export CLUSTER_SPEC=~/cluster.yaml
 export PUBKEY=~/.ssh/id_rsa.pub
+
+# details for S3 bucket to be used for assets
 export ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
 export ASSETS_ACCESS_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_access_key -)
 export ASSETS_SECRET_KEY=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_secret_key -)
+
+# depends on region, for example "https://s3.eu-central-1.amazonaws.com:443"
 export ASSETS_S3_ENDPOINT=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_s3_endpoint -)
 ```
 

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -34,6 +34,11 @@ if [[ -z ${ASSETS_BUCKET_NAME} ]]; then
   exit 1
 fi
 
+if [[ -z ${ASSETS_S3_ENDPOINT} ]]; then
+  echo "ASSETS_S3_ENDPOINT is not set. Make sure you set credentials and location for S3 outputs bucket."
+  exit 1
+fi
+
 kops create -f $CLUSTER_SPEC
 kops create secret --name $NAME sshpublickey admin -i $PUBKEY
 kops update cluster $NAME --yes
@@ -51,6 +56,7 @@ echo "Add secret for S3 bucket"
 echo
 kubectl create secret generic assets-s3-bucket --from-literal=access-key="$ASSETS_ACCESS_KEY" \
                                                --from-literal=secret-key="$ASSETS_SECRET_KEY" \
+                                               --from-literal=s3-endpoint="$ASSETS_S3_ENDPOINT" \
                                                --from-literal=bucket-name="$ASSETS_BUCKET_NAME"
 
 

--- a/infra/k8s/kops-weave/s3bucket.yml
+++ b/infra/k8s/kops-weave/s3bucket.yml
@@ -41,7 +41,10 @@ spec:
             - name: MNT_POINT
               value: "/s3fs-mount"
             - name: S3_ENDPOINT
-              value: "https://s3.eu-central-1.amazonaws.com:443"
+              valueFrom:
+                secretKeyRef:
+                  name: assets-s3-bucket
+                  key: s3-endpoint
             - name: S3_EXTRAVARS
               value: ",use_path_request_style"
           volumeMounts:


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/537

---

Region and endpoint are not technically a secret, but we are keeping all the configs for the S3 bucket at one place.

@aschmahmann for your env, this looks like:
```
2020-02-12 10:51:30         21 assets_adin_access_key
2020-02-12 10:51:44         22 assets_adin_bucket_name
2020-02-12 14:52:59         39 assets_adin_s3_endpoint
2020-02-12 10:51:38         41 assets_adin_secret_key
```

So the `export` calls are slightly different.