### PR TITLE
use shared ssh key for kops hosts ; command to extract kube context

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -56,6 +56,7 @@ aws s3api create-bucket \
 - set `kops` state store bucket
 - set number of worker nodes
 - set location for cluster spec to be generated
+- set location of your SSH public key
 - set credentials and locations for `outputs` S3 bucket
 
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
@@ -66,6 +67,7 @@ export ZONES=eu-central-1a
 export KOPS_STATE_STORE=s3://kops-backend-bucket
 export WORKER_NODES=4
 export CLUSTER_SPEC=~/cluster.yaml
+export PUBKEY=~/.ssh/testground_rsa.pub
 
 # details for S3 bucket to be used for assets
 export ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
@@ -110,7 +112,7 @@ helm repo update
 ## Apply the cluster configuration and create cloud resources and install Testground dependencies
 
 ```
-./install.sh $NAME $CLUSTER_SPEC $WORKER_NODES
+./install.sh $NAME $CLUSTER_SPEC $PUBKEY $WORKER_NODES
 ```
 
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -55,7 +55,6 @@ aws s3api create-bucket \
 - set `kops` state store bucket
 - set number of worker nodes
 - set location for cluster spec to be generated
-- set location of your SSH public key
 - set credentials and locations for `outputs` S3 bucket
 
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)
@@ -66,7 +65,6 @@ export ZONES=eu-central-1a
 export KOPS_STATE_STORE=s3://kops-backend-bucket
 export WORKER_NODES=4
 export CLUSTER_SPEC=~/cluster.yaml
-export PUBKEY=~/.ssh/testground_rsa.pub
 
 # details for S3 bucket to be used for assets
 export ASSETS_BUCKET_NAME=$(aws s3 cp s3://assets-s3-bucket-credentials/assets_bucket_name -)
@@ -111,7 +109,7 @@ helm repo update
 ## Apply the cluster configuration and create cloud resources and install Testground dependencies
 
 ```
-./install.sh $NAME $CLUSTER_SPEC $PUBKEY $WORKER_NODES
+./install.sh $NAME $CLUSTER_SPEC $WORKER_NODES
 ```
 
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -42,6 +42,12 @@ aws s3 cp s3://kops-shared-key-bucket/testground_rsa.pub ~/.ssh/
 chmod 700 ~/.ssh/testground_rsa
 ```
 
+Or generate your own key, for example
+
+```
+ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+```
+
 3. Create a bucket for `kops` state. This is similar to Terraform state bucket.
 
 ```
@@ -56,7 +62,7 @@ aws s3api create-bucket \
 - set `kops` state store bucket
 - set number of worker nodes
 - set location for cluster spec to be generated
-- set location of your SSH public key
+- set location of your cluster SSH public key
 - set credentials and locations for `outputs` S3 bucket
 
 You might want to add them to your `rc` file (`.zshrc`, `.bashrc`, etc.)

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -38,7 +38,8 @@ In order to have two different networks attached to pods in Kubernetes, we run t
 
 ```
 aws s3 cp s3://kops-shared-key-bucket/testground_rsa ~/.ssh/
-aws s3 cp s3://kops-shared-key-bucket/testground_rsa.pub ~/.ssh/                                                                                                                                                                  <<<
+aws s3 cp s3://kops-shared-key-bucket/testground_rsa.pub ~/.ssh/
+chmod 700 ~/.ssh/testground_rsa
 ```
 
 3. Create a bucket for `kops` state. This is similar to Terraform state bucket.

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -10,12 +10,10 @@ echo
 
 NAME=$1
 CLUSTER_SPEC=$2
-PUBKEY=$3
-WORKER_NODES=$4
+WORKER_NODES=$3
 
 echo "Name: $NAME"
 echo "Cluster spec: $CLUSTER_SPEC"
-echo "Public key: $PUBKEY"
 echo "Worker nodes: $WORKER_NODES"
 echo
 
@@ -40,7 +38,7 @@ if [[ -z ${ASSETS_S3_ENDPOINT} ]]; then
 fi
 
 kops create -f $CLUSTER_SPEC
-kops create secret --name $NAME sshpublickey admin -i $PUBKEY
+kops create secret --name $NAME sshpublickey admin -i ~/.ssh/testground_rsa.pub
 kops update cluster $NAME --yes
 
 ## wait for worker nodes and master to be ready

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -10,10 +10,12 @@ echo
 
 NAME=$1
 CLUSTER_SPEC=$2
-WORKER_NODES=$3
+PUBKEY=$3
+WORKER_NODES=$4
 
 echo "Name: $NAME"
 echo "Cluster spec: $CLUSTER_SPEC"
+echo "Public key: $PUBKEY"
 echo "Worker nodes: $WORKER_NODES"
 echo
 
@@ -38,7 +40,7 @@ if [[ -z ${ASSETS_S3_ENDPOINT} ]]; then
 fi
 
 kops create -f $CLUSTER_SPEC
-kops create secret --name $NAME sshpublickey admin -i ~/.ssh/testground_rsa.pub
+kops create secret --name $NAME sshpublickey admin -i $PUBKEY
 kops update cluster $NAME --yes
 
 ## wait for worker nodes and master to be ready


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/550

---

With this, if we need to log to another cluster, we just have to update the context for the local kubectl client with:
```
kops export kubecfg --state $KOPS_STATE_STORE --name=$NAME
```

And then we already have the SSH keys to log to the hosts.