### PR TITLE
expose pprof port on sidecar

### DIFF
--- a/cmd/sidecar.go
+++ b/cmd/sidecar.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"runtime"
 	"strings"
 
+	"github.com/ipfs/testground/pkg/logging"
 	"github.com/ipfs/testground/pkg/sidecar"
 	"github.com/urfave/cli"
 )
@@ -32,6 +35,10 @@ var SidecarCommand = cli.Command{
 				Allowed: sidecar.GetRunners(),
 			},
 		},
+		cli.BoolFlag{
+			Name:  "pprof",
+			Usage: "Enable pprof service on port 6060",
+		},
 	},
 }
 
@@ -39,5 +46,11 @@ func sidecarCommand(c *cli.Context) error {
 	if runtime.GOOS != "linux" {
 		return ErrNotLinux
 	}
+
+	if c.Bool("pprof") {
+		logging.S().Info("starting pprof")
+		go http.ListenAndServe(":6060", nil)
+	}
+
 	return sidecar.Run(c.String("runner"))
 }

--- a/cmd/sidecar.go
+++ b/cmd/sidecar.go
@@ -49,7 +49,9 @@ func sidecarCommand(c *cli.Context) error {
 
 	if c.Bool("pprof") {
 		logging.S().Info("starting pprof")
-		go http.ListenAndServe(":6060", nil)
+		go func() {
+			_ = http.ListenAndServe(":6060", nil)
+		}()
 	}
 
 	return sidecar.Run(c.String("runner"))

--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -49,6 +49,9 @@ spec:
         env:
         - name: REDIS_HOST
           value: "redis-headless"
+        ports:
+        - name: pprof
+          containerPort: 6060
         resources:
           limits:
             memory: 1024Mi

--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -41,7 +41,7 @@ spec:
         image: ipfs/testground:edge
         imagePullPolicy: Always
         command: ["testground"]
-        args: ["--vv", "sidecar", "--runner", "k8s"]
+        args: ["--vv", "sidecar", "--runner", "k8s", "--pprof"]
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "SYS_ADMIN", "SYS_TIME"]


### PR DESCRIPTION
TODO:
- [x] add a flag to sidecar so that it actually starts pprof on 6060

We could template this, so that a dev can enable/disable pprof, but for now we can assume that `sidecar.yaml` is setup correctly (enabled or disabled) and be done with it - I don't want to introduce another level of indirection.

---

Fixes: https://github.com/ipfs/testground/issues/423