### PR TITLE
feat: terminate command and interfaces

### DIFF
--- a/cmd/all.go
+++ b/cmd/all.go
@@ -21,6 +21,7 @@ var Commands = []cli.Command{
 	SidecarCommand,
 	DaemonCommand,
 	CollectCommand,
+	TerminateCommand,
 }
 
 var Flags = []cli.Flag{

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/ipfs/testground/pkg/client"
+	"github.com/urfave/cli"
+)
+
+var TerminateCommand = cli.Command{
+	Name:   "terminate",
+	Usage:  " terminates all jobs running on a runner",
+	Action: terminateCommand,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:     "runner",
+			Usage:    "specifies the runner to use; values include: 'local:exec', 'local:docker', 'cluster:k8s'",
+			Required: true,
+		},
+	},
+}
+
+func terminateCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
+	runner := c.String("runner")
+
+	api, err := setupClient(c)
+	if err != nil {
+		return err
+	}
+
+	r, err := api.Terminate(ctx, &client.TerminateRequest{
+		Runner: runner,
+	})
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	return client.ParseTerminateRequest(r)
+}

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -19,6 +19,7 @@ type Engine interface {
 	DoBuild(context.Context, *Composition, io.Writer) ([]*BuildOutput, error)
 	DoRun(context.Context, *Composition, io.Writer) (*RunOutput, error)
 	DoCollectOutputs(ctx context.Context, runner string, runID string, w io.Writer) error
+	DoTerminate(ctx context.Context, runner string, w io.Writer) error
 
 	EnvConfig() config.EnvConfig
 	Context() context.Context

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -94,3 +94,9 @@ type CollectionInput struct {
 	// plan manifest, coalesced with any user-provided overrides.
 	RunnerConfig interface{}
 }
+
+// Terminatable is the interface to be implemented by a runner that can be
+// terminated.
+type Terminatable interface {
+	TerminateAll() error
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -105,6 +105,17 @@ func (c *Client) CollectOutputs(ctx context.Context, r *OutputsRequest) (io.Read
 	return c.request(ctx, "POST", "/outputs", bytes.NewReader(body.Bytes()))
 }
 
+// Terminate sned a `terminate` request to the daemon.
+func (c *Client) Terminate(ctx context.Context, r *TerminateRequest) (io.ReadCloser, error) {
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.request(ctx, "POST", "/terminate", bytes.NewReader(body.Bytes()))
+}
+
 func parseGeneric(r io.ReadCloser, fnProgress, fnResult func(interface{}) error) error {
 	var msg tgwriter.Msg
 
@@ -182,6 +193,17 @@ func ParseBuildResponse(r io.ReadCloser) (BuildResponse, error) {
 
 // ParseDescribeResponse parses a response from a `describe` call
 func ParseDescribeResponse(r io.ReadCloser) error {
+	return parseGeneric(
+		r,
+		printProgress,
+		func(result interface{}) error {
+			return nil
+		},
+	)
+}
+
+// ParseTerminateRequest parses a response from a 'terminate' call
+func ParseTerminateRequest(r io.ReadCloser) error {
 	return parseGeneric(
 		r,
 		printProgress,

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -26,3 +26,7 @@ type OutputsRequest struct {
 	Runner string `json:"runner"`
 	RunID  string `json:"run_id"`
 }
+
+type TerminateRequest struct {
+	Runner string `json:"runner"`
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -49,6 +49,7 @@ func New(listenAddr string) (srv *Daemon, err error) {
 	r.HandleFunc("/build", srv.buildHandler(engine)).Methods("POST")
 	r.HandleFunc("/run", srv.runHandler(engine)).Methods("POST")
 	r.HandleFunc("/outputs", srv.outputsHandler(engine)).Methods("POST")
+	r.HandleFunc("/terminate", srv.terminateHandler(engine)).Methods("POST")
 
 	srv.doneCh = make(chan struct{})
 	srv.server = &http.Server{

--- a/pkg/daemon/terminate.go
+++ b/pkg/daemon/terminate.go
@@ -1,0 +1,38 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ipfs/testground/pkg/api"
+	"github.com/ipfs/testground/pkg/client"
+	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
+)
+
+func (srv *Daemon) terminateHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log := logging.S().With("ruid", r.Header.Get("X-Request-ID"))
+
+		log.Debugw("handle request", "command", "terminate")
+		defer log.Debugw("request handled", "command", "terminate")
+
+		tgw := tgwriter.New(w, log)
+
+		var req client.TerminateRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			tgw.WriteError("terminate json decode", "err", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		err = engine.DoTerminate(r.Context(), req.Runner, tgw)
+		if err != nil {
+			tgw.WriteError("terminate error", "err", err.Error())
+			return
+		}
+
+		tgw.WriteResult("Done")
+	}
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -430,6 +430,31 @@ func (e *Engine) DoCollectOutputs(ctx context.Context, runner string, runID stri
 	return run.CollectOutputs(ctx, input, w)
 }
 
+func (e *Engine) DoTerminate(ctx context.Context, runner string, w io.Writer) error {
+	run, ok := e.runners[runner]
+	if !ok {
+		return fmt.Errorf("unknown runner: %s", runner)
+	}
+
+	terminatable, ok := run.(api.Terminatable)
+	if !ok {
+		return fmt.Errorf("runner %s is not terminatable", runner)
+	}
+
+	_, err := w.Write([]byte("terminating all jobs on runner " + runner + "\n"))
+	if err != nil {
+		return err
+	}
+
+	err = terminatable.TerminateAll()
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write([]byte("all jobs on runner " + runner + " were terminated\n"))
+	return err
+}
+
 // EnvConfig returns the EnvConfig for this Engine.
 func (e *Engine) EnvConfig() config.EnvConfig {
 	return *e.envcfg


### PR DESCRIPTION
This is related to #432 and adds the `terminate` command and the `Terminatable` interface.

I decided to do this on smaller PRs.

On this PR:
- A single-method interface Terminatable: TerminateAll() error that runners supporting termination can implement.

What's missing to do on separate PRs:
- Implement `TerminateAll() error` for each runner.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>