### PR TITLE
measure when testground is ready and testplans are running

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,6 +76,14 @@ var RunCommand = cli.Command{
 					Name:  "test-param, p",
 					Usage: "provide a test parameter",
 				},
+				cli.BoolFlag{
+					Name:  "collect",
+					Usage: "Collect assets at the end of the run phase.",
+				},
+				cli.StringFlag{
+					Name:  "collect-file, o",
+					Usage: "Destination for the assets if --collect is set",
+				},
 			),
 		},
 	},

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -56,6 +56,12 @@ const (
 	// note that there are other services running on the Kubernetes cluster such as
 	// api proxy, kubedns, s3bucket, etc.
 	utilisation = 0.8
+
+	// magic values that we monitor on the Testground runner side to detect when Testground
+	// testplan instances are initialised and at the stage of actually running a test
+	// check sdk/sync for more information
+	NetworkInitialisationSuccessful = "network initialisation successful"
+	NetworkInitialisationFailed     = "network initialisation failed"
 )
 
 var (
@@ -401,7 +407,7 @@ func isNetworkInitialised(ctx context.Context, pool *pool, podName string) error
 			return ctx.Err()
 		default:
 			line := scanner.Text()
-			if strings.Contains(line, "network initialisation successful") {
+			if strings.Contains(line, NetworkInitialisationSuccessful) {
 				return nil
 			}
 		}

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -502,7 +502,7 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 
 		if counters["Running"] == input.TotalInstances && !allRunningStage {
 			allRunningStage = true
-			log.Infow("all testplan instances in `Running` state", "took", time.Now().Sub(start))
+			log.Infow("all testplan instances in `Running` state", "took", time.Since(start))
 
 			go func() {
 				_ = areNetworksInitialised(ctx, pool, log, input.RunID, k8sNamespace, initialisedNetworks)
@@ -511,11 +511,11 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 
 		if initNets == input.TotalInstances && !allNetworksStage {
 			allNetworksStage = true
-			log.Infow("all testplan instances networks initialised", "took", time.Now().Sub(start))
+			log.Infow("all testplan instances networks initialised", "took", time.Since(start))
 		}
 
 		if counters["Succeeded"] == input.TotalInstances {
-			log.Infow("all testplan instances in `Succeeded` state", "took", time.Now().Sub(start))
+			log.Infow("all testplan instances in `Succeeded` state", "took", time.Since(start))
 			return nil
 		}
 

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -511,7 +511,7 @@ func (c *ClusterK8sRunner) monitorTestplanRunState(ctx context.Context, log *zap
 		wg.Wait()
 
 		initNets := int(atomic.LoadUint64(initialisedNetworks))
-		log.Debugw("testplan pods state", "succeeded", counters["Succeeded"], "running", counters["Running"], "pending", counters["Pending"], "failed", counters["Failed"], "unknown", counters["Unknown"])
+		log.Debugw("testplan pods state", "running_for", time.Since(start), "succeeded", counters["Succeeded"], "running", counters["Running"], "pending", counters["Pending"], "failed", counters["Failed"], "unknown", counters["Unknown"])
 
 		if counters["Running"] == input.TotalInstances && !allRunningStage {
 			allRunningStage = true

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -33,7 +33,6 @@ import (
 	"go.uber.org/zap"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,7 +40,8 @@ import (
 )
 
 var (
-	_ api.Runner = &ClusterK8sRunner{}
+	_    api.Runner = &ClusterK8sRunner{}
+	once            = sync.Once{}
 )
 
 const (
@@ -110,7 +110,15 @@ type ClusterK8sRunnerConfig struct {
 
 // ClusterK8sRunner is a runner that creates a Docker service to launch as
 // many replicated instances of a container as the run job indicates.
-type ClusterK8sRunner struct{}
+type ClusterK8sRunner struct {
+	config KubernetesConfig
+	pool   *pool
+
+	podResourceCPU    resource.Quantity
+	podResourceMemory resource.Quantity
+
+	maxAllowedPods int
+}
 
 type KubernetesConfig struct {
 	// KubeConfigPath is the path to your kubernetes configuration path
@@ -129,11 +137,26 @@ func defaultKubernetesConfig() KubernetesConfig {
 	}
 }
 
-func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
 	var (
 		log = logging.S().With("runner", "cluster:k8s", "run_id", input.RunID)
 		cfg = *input.RunnerConfig.(*ClusterK8sRunnerConfig)
 	)
+
+	// init Kubernetes runner
+	once.Do(func() {
+		c.config = defaultKubernetesConfig()
+
+		var err error
+		workers := 20
+		c.pool, err = newPool(workers, c.config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		c.podResourceCPU = resource.MustParse(cfg.PodResourceCPU)
+		c.podResourceMemory = resource.MustParse(cfg.PodResourceMemory)
+	})
 
 	// Sanity check.
 	if input.Seq < 0 || input.Seq >= len(input.TestPlan.TestCases) {
@@ -162,21 +185,13 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 
 	template.TestSubnet = &runtime.IPNet{IPNet: *subnet}
 
-	k8sConfig := defaultKubernetesConfig()
-
-	workers := 20
-	pool, err := newPool(workers, k8sConfig)
+	c.maxAllowedPods, err = c.maxPods() // TODO: maybe move to the `init` / runner constructor at some point
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't calculate max pod allowance on the cluster: %v", err)
 	}
 
-	maxAllowedPods, err := maxPods(pool, resource.MustParse(cfg.PodResourceCPU))
-	if err != nil {
-		return nil, err
-	}
-
-	if maxAllowedPods < input.TotalInstances {
-		return nil, fmt.Errorf("too many test instances requested, max is %d, resize cluster if you need more capacity", maxAllowedPods)
+	if c.maxAllowedPods < input.TotalInstances {
+		return nil, fmt.Errorf("too many test instances requested, max is %d, resize cluster if you need more capacity", c.maxAllowedPods)
 	}
 
 	jobName := fmt.Sprintf("tg-%s", input.TestPlan.Name)
@@ -190,7 +205,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 	var initialisedNetworks uint64
 
 	eg.Go(func() error {
-		return monitorTestplanRunState(ctx, pool, log, input, k8sConfig.Namespace, &initialisedNetworks)
+		return c.monitorTestplanRunState(ctx, log, input, &initialisedNetworks)
 	})
 
 	sem := make(chan struct{}, 30) // limit the number of concurrent k8s api calls
@@ -224,9 +239,9 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 				if cfg.KeepService {
 					return
 				}
-				client := pool.Acquire()
-				defer pool.Release(client)
-				err = client.CoreV1().Pods(k8sConfig.Namespace).Delete(podName, &metav1.DeleteOptions{})
+				client := c.pool.Acquire()
+				defer c.pool.Release(client)
+				err = client.CoreV1().Pods(c.config.Namespace).Delete(podName, &metav1.DeleteOptions{})
 				if err != nil {
 					log.Errorw("couldn't remove pod", "pod", podName, "err", err)
 				}
@@ -235,7 +250,7 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 			eg.Go(func() error {
 				defer func() { <-sem }()
 
-				return createPod(ctx, pool, podName, input, runenv, env, k8sConfig.Namespace, g, i)
+				return c.createPod(ctx, podName, input, runenv, env, g, i)
 			})
 		}
 	}
@@ -248,7 +263,6 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 	var gg errgroup.Group
 
 	for _, g := range input.Groups {
-
 		for i := 0; i < g.Instances; i++ {
 			i := i
 			sem <- struct{}{}
@@ -256,12 +270,9 @@ func (*ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.Wri
 			gg.Go(func() error {
 				defer func() { <-sem }()
 
-				client := pool.Acquire()
-				defer pool.Release(client)
-
 				podName := fmt.Sprintf("%s-%s-%s-%d", jobName, input.RunID, g.ID, i)
 
-				logs, err := getPodLogs(client, log, k8sConfig.Namespace, podName)
+				logs, err := c.getPodLogs(log, podName)
 				if err != nil {
 					return err
 				}
@@ -345,7 +356,10 @@ func (*ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collecti
 	return nil
 }
 
-func getPodLogs(clientset *kubernetes.Clientset, log *zap.SugaredLogger, k8sNamespace string, podName string) (string, error) {
+func (c *ClusterK8sRunner) getPodLogs(log *zap.SugaredLogger, podName string) (string, error) {
+	client := c.pool.Acquire()
+	defer c.pool.Release(client)
+
 	podLogOpts := v1.PodLogOptions{
 		TailLines: int64Ptr(2),
 	}
@@ -353,7 +367,7 @@ func getPodLogs(clientset *kubernetes.Clientset, log *zap.SugaredLogger, k8sName
 	var podLogs io.ReadCloser
 	var err error
 	err = retry(5, 5*time.Second, func() error {
-		req := clientset.CoreV1().Pods(k8sNamespace).GetLogs(podName, &podLogOpts)
+		req := client.CoreV1().Pods(c.config.Namespace).GetLogs(podName, &podLogOpts)
 		podLogs, err = req.Stream()
 		if err != nil {
 			log.Warnw("got error when trying to fetch pod logs", "err", err.Error())
@@ -374,12 +388,12 @@ func getPodLogs(clientset *kubernetes.Clientset, log *zap.SugaredLogger, k8sName
 	return buf.String(), nil
 }
 
-func areNetworksInitialised(ctx context.Context, pool *pool, log *zap.SugaredLogger, k8sNamespace string, runID string, initialisedNetworks *uint64) error {
-	client := pool.Acquire()
-	res, err := client.CoreV1().Pods(k8sNamespace).List(metav1.ListOptions{
+func (c *ClusterK8sRunner) areNetworksInitialised(ctx context.Context, log *zap.SugaredLogger, runID string, initialisedNetworks *uint64) error {
+	client := c.pool.Acquire()
+	res, err := client.CoreV1().Pods(c.config.Namespace).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("testground.run_id=%s", runID),
 	})
-	pool.Release(client)
+	c.pool.Release(client)
 	if err != nil {
 		return err
 	}
@@ -387,11 +401,10 @@ func areNetworksInitialised(ctx context.Context, pool *pool, log *zap.SugaredLog
 	var eg errgroup.Group
 
 	for _, pod := range res.Items {
-
 		podName := pod.Name
 
 		eg.Go(func() error {
-			err := isNetworkInitialised(ctx, pool, log, podName)
+			err := c.isNetworkInitialised(ctx, log, podName)
 			if err != nil {
 				return err
 			}
@@ -405,7 +418,7 @@ func areNetworksInitialised(ctx context.Context, pool *pool, log *zap.SugaredLog
 	return eg.Wait()
 }
 
-func isNetworkInitialised(ctx context.Context, pool *pool, log *zap.SugaredLogger, podName string) error {
+func (c *ClusterK8sRunner) isNetworkInitialised(ctx context.Context, log *zap.SugaredLogger, podName string) error {
 	podLogOpts := v1.PodLogOptions{
 		SinceSeconds: int64Ptr(1000),
 		Follow:       true,
@@ -414,9 +427,9 @@ func isNetworkInitialised(ctx context.Context, pool *pool, log *zap.SugaredLogge
 	var podLogs io.ReadCloser
 	var err error
 	err = retry(5, 5*time.Second, func() error {
-		client := pool.Acquire()
-		req := client.CoreV1().Pods("default").GetLogs(podName, &podLogOpts)
-		pool.Release(client)
+		client := c.pool.Acquire()
+		req := client.CoreV1().Pods(c.config.Namespace).GetLogs(podName, &podLogOpts)
+		c.pool.Release(client)
 		podLogs, err = req.Stream()
 		if err != nil {
 			log.Warnw("got error when trying to fetch pod logs", "err", err.Error())
@@ -444,9 +457,9 @@ func isNetworkInitialised(ctx context.Context, pool *pool, log *zap.SugaredLogge
 	return errors.New("network initialisation successful log line not detected")
 }
 
-func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLogger, input *api.RunInput, k8sNamespace string, initialisedNetworks *uint64) error {
-	client := pool.Acquire()
-	defer pool.Release(client)
+func (c *ClusterK8sRunner) monitorTestplanRunState(ctx context.Context, log *zap.SugaredLogger, input *api.RunInput, initialisedNetworks *uint64) error {
+	client := c.pool.Acquire()
+	defer c.pool.Release(client)
 
 	start := time.Now()
 	allRunningStage := false
@@ -469,7 +482,7 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 				LabelSelector: fmt.Sprintf("testground.run_id=%s", input.RunID),
 				FieldSelector: fieldSelector,
 			}
-			res, err := client.CoreV1().Pods(k8sNamespace).List(opts)
+			res, err := client.CoreV1().Pods(c.config.Namespace).List(opts)
 			if err != nil {
 				log.Warnw("k8s client pods list error", "err", err.Error())
 				return -1
@@ -505,7 +518,7 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 			log.Infow("all testplan instances in `Running` state", "took", time.Since(start))
 
 			go func() {
-				_ = areNetworksInitialised(ctx, pool, log, input.RunID, k8sNamespace, initialisedNetworks)
+				_ = c.areNetworksInitialised(ctx, log, input.RunID, initialisedNetworks)
 			}()
 		}
 
@@ -522,11 +535,9 @@ func monitorTestplanRunState(ctx context.Context, pool *pool, log *zap.SugaredLo
 	}
 }
 
-func createPod(ctx context.Context, pool *pool, podName string, input *api.RunInput, runenv runtime.RunParams, env []v1.EnvVar, k8sNamespace string, g api.RunGroup, i int) error {
-	cfg := *input.RunnerConfig.(*ClusterK8sRunnerConfig)
-
-	client := pool.Acquire()
-	defer pool.Release(client)
+func (c *ClusterK8sRunner) createPod(ctx context.Context, podName string, input *api.RunInput, runenv runtime.RunParams, env []v1.EnvVar, g api.RunGroup, i int) error {
+	client := c.pool.Acquire()
+	defer c.pool.Release(client)
 
 	mountPropagationMode := v1.MountPropagationHostToContainer
 	hostpathtype := v1.HostPathType("DirectoryOrCreate")
@@ -580,8 +591,8 @@ func createPod(ctx context.Context, pool *pool, podName string, input *api.RunIn
 					},
 					Resources: v1.ResourceRequirements{
 						Limits: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse(cfg.PodResourceMemory),
-							v1.ResourceCPU:    resource.MustParse(cfg.PodResourceCPU),
+							v1.ResourceMemory: c.podResourceMemory,
+							v1.ResourceCPU:    c.podResourceCPU,
 						},
 					},
 				},
@@ -589,7 +600,7 @@ func createPod(ctx context.Context, pool *pool, podName string, input *api.RunIn
 		},
 	}
 
-	_, err := client.CoreV1().Pods(k8sNamespace).Create(podRequest)
+	_, err := client.CoreV1().Pods(c.config.Namespace).Create(podRequest)
 	return err
 }
 
@@ -606,14 +617,14 @@ func (fw FakeWriterAt) WriteAt(p []byte, offset int64) (n int, err error) {
 
 // maxPods returns the max allowed pods for the current cluster size
 // at the moment we are CPU bound, so this is based only on rough estimation of available CPUs
-func maxPods(pool *pool, podResourceCPU resource.Quantity) (int, error) {
-	podCPU, err := strconv.ParseFloat(podResourceCPU.AsDec().String(), 64)
+func (c *ClusterK8sRunner) maxPods() (int, error) {
+	podCPU, err := strconv.ParseFloat(c.podResourceCPU.AsDec().String(), 64)
 	if err != nil {
 		return 0, err
 	}
 
-	client := pool.Acquire()
-	defer pool.Release(client)
+	client := c.pool.Acquire()
+	defer c.pool.Release(client)
 
 	res, err := client.CoreV1().Nodes().List(metav1.ListOptions{
 		LabelSelector: "kubernetes.io/role=node",

--- a/sdk/sync/helper.go
+++ b/sdk/sync/helper.go
@@ -7,15 +7,23 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
+const (
+	// magic values that we monitor on the Testground runner side to detect when Testground
+	// testplan instances are initialised and at the stage of actually running a test
+	// check cluster_k8s.go for more information
+	NetworkInitialisationSuccessful = "network initialisation successful"
+	NetworkInitialisationFailed     = "network initialisation failed"
+)
+
 // WaitNetworkInitialized waits for the sidecar to initialize the network, if the sidecar is enabled.
 func WaitNetworkInitialized(ctx context.Context, runenv *runtime.RunEnv, watcher *Watcher) error {
 	if runenv.TestSidecar {
 		err := <-watcher.Barrier(ctx, "network-initialized", int64(runenv.TestInstanceCount))
 		if err != nil {
-			runenv.RecordMessage("network initialisation failed")
+			runenv.RecordMessage(NetworkInitialisationFailed)
 			return fmt.Errorf("failed to initialize network: %w", err)
 		}
 	}
-	runenv.RecordMessage("network initialisation successful")
+	runenv.RecordMessage(NetworkInitialisationSuccessful)
 	return nil
 }

--- a/sdk/sync/helper.go
+++ b/sdk/sync/helper.go
@@ -12,8 +12,10 @@ func WaitNetworkInitialized(ctx context.Context, runenv *runtime.RunEnv, watcher
 	if runenv.TestSidecar {
 		err := <-watcher.Barrier(ctx, "network-initialized", int64(runenv.TestInstanceCount))
 		if err != nil {
+			runenv.RecordMessage("network initialisation failed")
 			return fmt.Errorf("failed to initialize network: %w", err)
 		}
 	}
+	runenv.RecordMessage("network initialisation successful")
 	return nil
 }


### PR DESCRIPTION
This is prerequisite for the k8s<->sidecar coordination, so that at least I can see that after getting rid of the 20sec. we still initialise correctly all networks, rather than have to review all logs (sidecar) across clusters.