### PR TITLE
refactor k8s cluster runner

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -151,7 +151,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 		workers := 20
 		c.pool, err = newPool(workers, c.config)
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 
 		c.podResourceCPU = resource.MustParse(cfg.PodResourceCPU)
@@ -159,7 +159,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 
 		c.maxAllowedPods, err = c.maxPods()
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 	})
 
@@ -263,7 +263,6 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 	var gg errgroup.Group
 
 	for _, g := range input.Groups {
-
 		for i := 0; i < g.Instances; i++ {
 			i := i
 			sem <- struct{}{}
@@ -402,7 +401,6 @@ func (c *ClusterK8sRunner) areNetworksInitialised(ctx context.Context, log *zap.
 	var eg errgroup.Group
 
 	for _, pod := range res.Items {
-
 		podName := pod.Name
 
 		eg.Go(func() error {

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -156,11 +156,6 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 
 		c.podResourceCPU = resource.MustParse(cfg.PodResourceCPU)
 		c.podResourceMemory = resource.MustParse(cfg.PodResourceMemory)
-
-		c.maxAllowedPods, err = c.maxPods()
-		if err != nil {
-			log.Fatal(err)
-		}
 	})
 
 	// Sanity check.
@@ -189,6 +184,11 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 	}
 
 	template.TestSubnet = &runtime.IPNet{IPNet: *subnet}
+
+	c.maxAllowedPods, err = c.maxPods() // TODO: maybe move to the `init` / runner constructor at some point
+	if err != nil {
+		return nil, fmt.Errorf("couldn't calculate max pod allowance on the cluster: %v", err)
+	}
 
 	if c.maxAllowedPods < input.TotalInstances {
 		return nil, fmt.Errorf("too many test instances requested, max is %d, resize cluster if you need more capacity", c.maxAllowedPods)


### PR DESCRIPTION
This is simplifying the signature for most methods in the Kubernetes runner, by pushing the Kubernetes related APIs to the runner itself, rather than providing them as function arguments all the time.