### PR TITLE
Add a state machine

### DIFF
--- a/manifests/example.toml
+++ b/manifests/example.toml
@@ -51,3 +51,7 @@ instances = { min = 1, max = 200, default = 1 }
 [[testcases]]
 name = "sync"
 instances = { min = 2, max = 200, default = 5 }
+
+[[testcases]]
+name = "statemachine"
+instances = { min = 1, max = 200, default = 5 }

--- a/plans/example/main.go
+++ b/plans/example/main.go
@@ -25,6 +25,8 @@ func run(runenv *runtime.RunEnv) error {
 		return ExampleParams(runenv)
 	case "sync":
 		return ExampleSync(runenv)
+	case "statemachine":
+		return ExampleStateMachine(runenv)
 	default:
 		msg := fmt.Sprintf("Unknown Testcase %s", c)
 		return errors.New(msg)

--- a/plans/example/statemachine.go
+++ b/plans/example/statemachine.go
@@ -7,6 +7,16 @@ import (
 	gort "runtime"
 )
 
+// The purpose of this example is to demonstrate the state machine as a primative for more complex
+// pattern generation.
+// In this example, the test is broken up into three phases, each does something slightly different.
+// Because each phase is a BarrierAllStateMachienNode, the function will begin with a sync barrier
+// which waits for all to enter the current phase before continuing with their work.
+
+// The benefit of this design is that the synchronization logic is entirely separated from the logic
+// of each test phase, even though the runtime (and perhaps other information) is shared between
+// phases.
+
 func PatternFactory(runenv *runtime.RunEnv, funcs ...func(runenv *runtime.RunEnv) error) *sync.BarrierAllStateMachineNode {
 	root := sync.NewBarrierAllStateMachineNode("outer", "setup", runenv)
 	root.OnEnter(func() error {

--- a/plans/example/statemachine.go
+++ b/plans/example/statemachine.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/ipfs/testground/sdk/sync"
+	"reflect"
+	gort "runtime"
+)
+
+func PatternFactory(runenv *runtime.RunEnv, funcs ...func(runenv *runtime.RunEnv) error) *sync.BarrierAllStateMachineNode {
+	root := sync.NewBarrierAllStateMachineNode("outer", "setup", runenv)
+	root.OnEnter(func() error {
+		return SetupStage(runenv)
+	})
+	current := root
+	for _, f := range funcs {
+		fname := gort.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+		runenv.RecordMessage("Adding %s to the success path.", fname)
+		newnode := sync.NewBarrierAllStateMachineNode("outer", fname, runenv)
+		fcpy := f
+		closure := sync.StateMachineExecutable(func() error {
+			return fcpy(runenv)
+		})
+		newnode.OnEnter(closure)
+		current.AttachSuccess(newnode)
+		current = newnode
+	}
+	end := sync.NewBarrierAllStateMachineNode("outer", "end", runenv)
+	end.OnEnter(func() error {
+		return TeardownStage(runenv)
+	})
+	current.AttachSuccess(end)
+	return root
+}
+
+func SetupStage(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("Setting up")
+	return nil
+}
+
+func TeardownStage(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("Tearing Down")
+	return nil
+}
+
+func Stage1(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("Stage 1")
+	return nil
+}
+
+func Stage2(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("Stage 2")
+	return nil
+}
+
+func Stage3(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("Stage 3")
+	return nil
+}
+
+func ExampleStateMachine(runenv *runtime.RunEnv) error {
+	runenv.RecordMessage("creating state machine with stage 1, 2, and 3")
+	sm := PatternFactory(runenv, Stage1, Stage2, Stage3)
+	_ = sm.Enter()
+	return nil
+}

--- a/sdk/sync/statemachine.go
+++ b/sdk/sync/statemachine.go
@@ -153,7 +153,7 @@ func (sm BarrierAllStateMachineNode) Enter() error {
 	if err != nil {
 		failmsg := fmt.Sprintf("%s-failed", sm.Name)
 		fstate := State(failmsg)
-		writer.SignalEntry(ctx, fstate)
+		_, _ = writer.SignalEntry(ctx, fstate)
 		sm.runenv.RecordFailure(errors.New(failmsg))
 		return sm.Fail(err).Enter()
 	}

--- a/sdk/sync/statemachine.go
+++ b/sdk/sync/statemachine.go
@@ -142,7 +142,10 @@ func (sm BarrierAllStateMachineNode) Enter() error {
 	watcher, writer := MustWatcherWriter(ctx, sm.runenv)
 
 	s := State(sm.Name)
-	writer.SignalEntry(ctx, s)
+	_, err := writer.SignalEntry(ctx, s)
+	if err != nil {
+		return sm.Fail(err).Enter()
+	}
 
 	// TODO, we should watch for -failed states, and fail when those are encountered
 	// For now, the context timeout will work.

--- a/sdk/sync/statemachine.go
+++ b/sdk/sync/statemachine.go
@@ -115,27 +115,27 @@ type BarrierAllStateMachineNode struct {
 	runenv      *runtime.RunEnv
 }
 
-func (sm BarrierAllStateMachineNode) Succeed() StateMachineNode {
+func (sm *BarrierAllStateMachineNode) Succeed() StateMachineNode {
 	return sm.successNode
 }
 
-func (sm BarrierAllStateMachineNode) Fail(err error) StateMachineNode {
+func (sm *BarrierAllStateMachineNode) Fail(err error) StateMachineNode {
 	return sm.failureNode
 }
 
-func (sm BarrierAllStateMachineNode) AttachSuccess(a StateMachineNode) {
+func (sm *BarrierAllStateMachineNode) AttachSuccess(a StateMachineNode) {
 	sm.successNode = a
 }
 
-func (sm BarrierAllStateMachineNode) AttachFailure(a StateMachineNode) {
+func (sm *BarrierAllStateMachineNode) AttachFailure(a StateMachineNode) {
 	sm.failureNode = a
 }
 
-func (sm BarrierAllStateMachineNode) OnEnter(e StateMachineExecutable) {
+func (sm *BarrierAllStateMachineNode) OnEnter(e StateMachineExecutable) {
 	sm.enterfunc = e
 }
 
-func (sm BarrierAllStateMachineNode) Enter() error {
+func (sm *BarrierAllStateMachineNode) Enter() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(2)*time.Minute)
 	defer cancel()
 

--- a/sdk/sync/statemachine.go
+++ b/sdk/sync/statemachine.go
@@ -149,7 +149,7 @@ func (sm BarrierAllStateMachineNode) Enter() error {
 
 	// TODO, we should watch for -failed states, and fail when those are encountered
 	// For now, the context timeout will work.
-	err := <-watcher.Barrier(ctx, s, int64(sm.runenv.TestInstanceCount))
+	err = <-watcher.Barrier(ctx, s, int64(sm.runenv.TestInstanceCount))
 	if err != nil {
 		failmsg := fmt.Sprintf("%s-failed", sm.Name)
 		fstate := State(failmsg)

--- a/sdk/sync/statemachine.go
+++ b/sdk/sync/statemachine.go
@@ -1,0 +1,174 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+//
+// Each state in this state machine has two edges which represent a failure and success paths.
+// To use the state machine, attach a funciton to the node using the OnEnter() method. This method
+// will be invoked at the right time when the state is Enter()'ed.
+// Each State can represent a phase of the test, with the approprate synchronization abstracted
+// away from the test logic.
+//
+// Example:
+// func DoSomething() error {
+//  ...
+// }
+//
+// func DoSomethingElse() error {
+//  ...
+// }
+///
+// s1 := NewBarrierAllStateMachineNode("main", "state1", runenv)
+// s2 := NewBarrierAllStateMachineNode("main", "state2", runenv)
+// s1.OnEnter(DoSomething)
+// s1.AttachSuccess(s2)
+// s2.OnEnter(DoSomethingElse)
+
+var BarrierExecuteError = errors.New("timeout waiting for barrier")
+
+type StateMachineExecutable func() error
+
+type StateMachineNode interface {
+	Succeed() StateMachineNode
+	Fail(e error) StateMachineNode
+	OnEnter(e StateMachineExecutable)
+	Enter() error
+	AttachSuccess(a StateMachineNode)
+	AttachFailure(a StateMachineNode)
+}
+
+// TerminalSuccessNode
+// This is a state machine endpoint.
+// Attaching nodes to this state will do nothing.
+// The Enter() method returns nil
+type TerminalSuccessNode struct {
+}
+
+func (sm TerminalSuccessNode) Succeed() StateMachineNode {
+	return sm
+}
+
+func (sm TerminalSuccessNode) Fail(e error) StateMachineNode {
+	return sm
+}
+
+func (sm TerminalSuccessNode) OnEnter(e StateMachineExecutable) {
+}
+
+func (sm TerminalSuccessNode) Enter() error {
+	return nil
+}
+
+func (sm TerminalSuccessNode) AttachSuccess(a StateMachineNode) {
+}
+
+func (sm TerminalSuccessNode) AttachFailure(a StateMachineNode) {
+}
+
+// TerminalFailureNode
+// This is a state machine endpoint.
+// Attaching nodes to this state will do nothing.
+// The Enter() method returns an error message.
+type TerminalFailureNode struct {
+}
+
+func (sm TerminalFailureNode) Succeed() StateMachineNode {
+	return sm
+}
+
+func (sm TerminalFailureNode) Fail(e error) StateMachineNode {
+	return sm
+}
+
+func (sm TerminalFailureNode) OnEnter(e StateMachineExecutable) {
+}
+
+func (sm TerminalFailureNode) Enter() error {
+	// This isn't a very descriptive message.
+	// Rather than providing more context here, maybe other error messages are more descriptive?
+	return errors.New("State machine reached a terminal state.")
+}
+
+func (sm TerminalFailureNode) AttachSuccess(a StateMachineNode) {
+}
+
+func (sm TerminalFailureNode) AttachFailure(a StateMachineNode) {
+}
+
+// A BarrierStateMachineNode is a fully synchronous state machine.
+// This state machine waits until all nodes are in the same state.
+// Most likely, the operand to the Enter method will be a closure method encapsulating
+// the task to be performed at a certain stage of the test plan.
+type BarrierAllStateMachineNode struct {
+	Name        string
+	stname      string
+	successNode StateMachineNode
+	failureNode StateMachineNode
+	enterfunc   StateMachineExecutable
+	runenv      *runtime.RunEnv
+}
+
+func (sm BarrierAllStateMachineNode) Succeed() StateMachineNode {
+	return sm.successNode
+}
+
+func (sm BarrierAllStateMachineNode) Fail(err error) StateMachineNode {
+	return sm.failureNode
+}
+
+func (sm BarrierAllStateMachineNode) AttachSuccess(a StateMachineNode) {
+	sm.successNode = a
+}
+
+func (sm BarrierAllStateMachineNode) AttachFailure(a StateMachineNode) {
+	sm.failureNode = a
+}
+
+func (sm BarrierAllStateMachineNode) OnEnter(e StateMachineExecutable) {
+	sm.enterfunc = e
+}
+
+func (sm BarrierAllStateMachineNode) Enter() error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(2)*time.Minute)
+	defer cancel()
+
+	watcher, writer := MustWatcherWriter(ctx, sm.runenv)
+
+	s := State(sm.Name)
+	writer.SignalEntry(ctx, s)
+
+	// TODO, we should watch for -failed states, and fail when those are encountered
+	// For now, the context timeout will work.
+	err := <-watcher.Barrier(ctx, s, int64(sm.runenv.TestInstanceCount))
+	if err != nil {
+		failmsg := fmt.Sprintf("%s-failed", sm.Name)
+		fstate := State(failmsg)
+		writer.SignalEntry(ctx, fstate)
+		sm.runenv.RecordFailure(errors.New(failmsg))
+		return sm.Fail(err).Enter()
+	}
+	err = sm.enterfunc()
+	if err != nil {
+		return sm.Fail(err).Enter()
+	}
+	return sm.Succeed().Enter()
+}
+
+func NewBarrierAllStateMachineNode(stname string, statename string, runenv *runtime.RunEnv) *BarrierAllStateMachineNode {
+	sm := BarrierAllStateMachineNode{
+		Name:        statename,
+		stname:      stname,
+		successNode: TerminalSuccessNode{},
+		failureNode: TerminalFailureNode{},
+		enterfunc:   func() error { return nil },
+		runenv:      runenv,
+	}
+	return &sm
+}


### PR DESCRIPTION
The purpose for this is to abstract away synchronization methods and allow modeling for patterns, such as plan factories. 