### PR TITLE
feat(sync): use a shared redis client

### DIFF
--- a/sdk/sync/redis_test.go
+++ b/sdk/sync/redis_test.go
@@ -28,11 +28,9 @@ func init() {
 func ensureRedis(t *testing.T) (close func()) {
 	t.Helper()
 
-	runenv := randomRunEnv()
-
 	// Try to obtain a client; if this fails, we'll attempt to start a redis
 	// instance.
-	client, err := redisClient(context.Background(), runenv)
+	client, err := redisClient(context.Background())
 	if err == nil {
 		client.Close()
 		return func() {}
@@ -46,7 +44,7 @@ func ensureRedis(t *testing.T) (close func()) {
 	time.Sleep(1 * time.Second)
 
 	// Try to obtain a client again.
-	if client, err = redisClient(context.Background(), runenv); err != nil {
+	if client, err = redisClient(context.Background()); err != nil {
 		t.Fatalf("failed to obtain redis client despite starting instance: %v", err)
 	}
 	defer client.Close()
@@ -325,7 +323,6 @@ func TestCloseSubscription(t *testing.T) {
 }
 
 func TestRedisHost(t *testing.T) {
-	runenv := randomRunEnv()
 	realRedisHost := os.Getenv(EnvRedisHost)
 	defer os.Setenv(EnvRedisHost, realRedisHost)
 
@@ -333,14 +330,14 @@ func TestRedisHost(t *testing.T) {
 	defer cancel()
 
 	os.Setenv(EnvRedisHost, "redis-does-not-exist.example.com")
-	client, err := redisClient(ctx, runenv)
+	client, err := redisClient(ctx)
 	if err == nil {
 		client.Close()
 		t.Error("should not have found redis host")
 	}
 
 	os.Setenv(EnvRedisHost, "redis-does-not-exist.example.com")
-	client, err = redisClient(ctx, runenv)
+	client, err = redisClient(ctx)
 	if err == nil {
 		client.Close()
 		t.Error("should not have found redis host")
@@ -351,7 +348,7 @@ func TestRedisHost(t *testing.T) {
 		realHost = "localhost"
 	}
 	os.Setenv(EnvRedisHost, realHost)
-	client, err = redisClient(ctx, runenv)
+	client, err = redisClient(ctx)
 	if err != nil {
 		t.Errorf("should have found the redis host, failed with: %s", err)
 	}

--- a/sdk/sync/watch.go
+++ b/sdk/sync/watch.go
@@ -14,10 +14,12 @@ import (
 
 // Watcher exposes methods to watch subtrees within the sync tree of this test.
 type Watcher struct {
-	re     *runtime.RunEnv
-	client *redis.Client
-	root   string
-	subs   sync.WaitGroup
+	re        *runtime.RunEnv
+	client    *redis.Client
+	root      string
+	subs      sync.WaitGroup
+	close     chan struct{}
+	closeOnce sync.Once
 }
 
 // NewWatcher begins watching the subtree underneath this path.
@@ -25,7 +27,7 @@ type Watcher struct {
 // NOTE: Canceling the context cancels the call to this function, it does not
 // affect the returned watcher.
 func NewWatcher(ctx context.Context, runenv *runtime.RunEnv) (w *Watcher, err error) {
-	client, err := redisClient(ctx, runenv)
+	client, err := getGlobalRedisClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("during redisClient: %w", err)
 	}
@@ -35,6 +37,7 @@ func NewWatcher(ctx context.Context, runenv *runtime.RunEnv) (w *Watcher, err er
 		re:     runenv,
 		client: client,
 		root:   prefix,
+		close:  make(chan struct{}),
 	}
 	return w, nil
 }
@@ -132,6 +135,9 @@ func (w *Watcher) Barrier(ctx context.Context, state State, required int64) <-ch
 				err := fmt.Errorf("%s waiting on %s; not enough elements, required %d, got %d", err, state, required, last)
 				resCh <- err
 				return
+			case <-w.close:
+				resCh <- fmt.Errorf("closed")
+				return
 			}
 		}
 		if last > required {
@@ -149,6 +155,9 @@ func (w *Watcher) Barrier(ctx context.Context, state State, required int64) <-ch
 //
 // Note: Concurrently closing the watcher while calling Subscribe may panic.
 func (w *Watcher) Close() error {
-	defer w.subs.Wait()
-	return w.client.Close()
+	w.closeOnce.Do(func() {
+		close(w.close)
+		w.subs.Wait()
+	})
+	return nil
 }

--- a/sdk/sync/write.go
+++ b/sdk/sync/write.go
@@ -51,7 +51,7 @@ type Writer struct {
 // NOTE: Canceling the context cancels the call to this function, it does not
 // affect the returned watcher.
 func NewWriter(ctx context.Context, runenv *runtime.RunEnv) (w *Writer, err error) {
-	client, err := redisClient(ctx, runenv)
+	client, err := getGlobalRedisClient(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The redis client is designed to be shared between many goroutines. We were creating separate redis instances everywhere. This meant:

1. Each test instance created two redis clients instead of one (write & watch).
2. The sidecar created two redis clients (and multiple connections) per test instance.

Worse, we weren't _closing_ writers. That meant we were leaking connections on the sidecar. This change sidesteps that problem by just sharing connections everywhere.