### PR TITLE
fix(sync): cancel all subscriptions when closing the watcher

### DIFF
--- a/sdk/sync/subscription.go
+++ b/sdk/sync/subscription.go
@@ -53,15 +53,17 @@ func (s *subscription) process() {
 	go func() {
 		defer close(closed)
 		select {
+		case <-s.w.close:
 		case <-s.client.Context().Done():
-			// we need a _non_ canceled client for this to work.
-			client := s.client.WithContext(context.Background())
-			err := client.ClientUnblockWithError(connID).Err()
-			if err != nil {
-				log.Errorw("failed to kill connection", "error", err)
-			}
 		case <-done:
 			// no need to unblock anything.
+			return
+		}
+		// we need a _non_ canceled client for this to work.
+		client := s.client.WithContext(context.Background())
+		err := client.ClientUnblockWithError(connID).Err()
+		if err != nil {
+			log.Errorw("failed to kill connection", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
Even if the user hasn't canceled the subscription's context.