### PR TITLE
fix: run the goproxy as the owner of the go package cache.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	go.uber.org/zap v1.12.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/tools v0.0.0-20191216052735-49a3e744a425 // indirect
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/pkg/build/golang/docker_other.go
+++ b/pkg/build/golang/docker_other.go
@@ -1,0 +1,7 @@
+//+build !linux,!darwin,!freebsd
+
+package golang
+
+func getOwner(path string) (owner string, err error) {
+	return "", nil
+}

--- a/pkg/build/golang/docker_unix.go
+++ b/pkg/build/golang/docker_unix.go
@@ -1,0 +1,19 @@
+//+build linux darwin freebsd
+
+package golang
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func getOwner(path string) (owner string, err error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	stat := info.Sys().(unix.Stat_t)
+	return fmt.Sprintf("%d:%d", stat.Uid, stat.Gid), nil
+}


### PR DESCRIPTION
This ensures we don't create files in the go package cache as the wrong user.

Also run the goproxy even if the local GOPATH doesn't exist. The goproxy container will use a volume so we'll still see some speedup.

fixes #505