### PR TITLE
adjust redis config

### DIFF
--- a/infra/k8s/redis-values.yaml
+++ b/infra/k8s/redis-values.yaml
@@ -185,7 +185,7 @@ securityContext:
   ##
   sysctls:
   - name: net.core.somaxconn
-    value: "10000"
+    value: "100000"
 
 ## Use password authentication
 usePassword: false
@@ -257,8 +257,8 @@ master:
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:
     requests:
-      memory: 2048Mi
-      cpu: 2000m
+      memory: 14000Mi
+      cpu: 7000m
   ## Use an alternate scheduler, e.g. "stork".
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##


### PR DESCRIPTION
A short-term hack to make sure that Redis is using a full c5.2xlarge machine.

If we don't do that, requests to Redis time out, because the testplan instances on that VM starve it.

We should review what is the best way to run Redis - for example I know it is single-threaded, so having multiple cores, doesn't really help it, unless we run multiple instances. This is out of scope for now.