### PR TITLE
handle already running containers

### DIFF
--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -62,7 +62,11 @@ func EnsureContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cl
 		return nil, false, err
 	}
 
-	if ci != nil && ci.State.Status != "running" {
+	if ci != nil {
+		if ci.State.Status == "running" {
+			log.Info("container is already running")
+			return ci, false, err
+		}
 		log.Infof("container isn't running; starting")
 
 		err := cli.ContainerStart(ctx, ci.ID, types.ContainerStartOptions{})


### PR DESCRIPTION
Bug:

When container is already running, I see an error that the container cannot be created because it already exists.


With this fix, we the following messages in different scenarios:
When the container is killed:
```
Feb 28 18:04:00.794792	INFO	performing build for group	{"plan": "example", "group": "single", "builder": "docker:go"}
Feb 28 18:04:00.797107	INFO	found existing volume	{"build_id": "1c0765d9484c", "volume_name": "testground-goproxy-vol"}
Feb 28 18:04:00.798812	INFO	container isn't running; starting	{"build_id": "1c0765d9484c", "container_name": "testground-goproxy"}
Feb 28 18:04:04.756539	INFO	build succeeded	{"plan": "example", "group": "single", "builder": "docker:go", "artifact": "1c0765d9484c"}

```
When the container is deleted:
```
Feb 28 18:04:17.590620	INFO	performing build for group	{"plan": "example", "group": "single", "builder": "docker:go"}
Feb 28 18:04:17.592744	INFO	found existing volume	{"build_id": "07d845358eea", "volume_name": "testground-goproxy-vol"}
Feb 28 18:04:17.593374	INFO	container not found; creating	{"build_id": "07d845358eea", "container_name": "testground-goproxy"}
latest: Pulling from goproxy/goproxy
latest: Digest: sha256:51affd3906d026995f95f2947ccf14b0de95871afe31e069d77090475954ac4a
latest: Status: Image is up to date for goproxy/goproxy:latest
Feb 28 18:04:19.173237	INFO	starting new container	{"build_id": "07d845358eea", "container_name": "testground-goproxy", "id": "a731fb32935c9439b2382223149120cab552b0b5778401be6bb88e415dd26f34"}
Feb 28 18:04:19.968433	INFO	started container	{"build_id": "07d845358eea", "container_name": "testground-goproxy", "id": "a731fb32935c9439b2382223149120cab552b0b5778401be6bb88e415dd26f34"}
Feb 28 18:04:19.969066	INFO	started container	{"build_id": "07d845358eea", "container_name": "testground-goproxy", "id": "a731fb32935c9439b2382223149120cab552b0b5778401be6bb88e415dd26f34"}
Feb 28 18:04:23.127521	INFO	build succeeded	{"plan": "example", "group": "single", "builder": "docker:go", "artifact": "07d845358eea"}
```

When the container already exists:
```
Feb 28 18:02:35.643908	INFO	listen and serve	{"addr": "[::]:8080"}
Feb 28 18:02:35.643956	INFO	daemon listening	{"addr": "[::]:8080"}
Feb 28 18:02:43.861788	INFO	performing build for group	{"plan": "example", "group": "single", "builder": "docker:go"}
Feb 28 18:02:43.863843	INFO	found existing volume	{"build_id": "295a63d0c981", "volume_name": "testground-goproxy-vol"}
Feb 28 18:02:43.865947	INFO	container is already running	{"build_id": "295a63d0c981", "container_name": "testground-goproxy"}
Feb 28 18:03:17.394631	INFO	build succeeded	{"plan": "example", "group": "single", "builder": "docker:go", "artifact": "295a63d0c981"}


```