### PR TITLE
example measurements - counters and timers

### DIFF
--- a/manifests/example.toml
+++ b/manifests/example.toml
@@ -62,3 +62,7 @@ instances = { min = 1, max = 200, default = 5 }
 [[testcases]]
 name = "prometheus2"
 instances = { min = 1, max = 200, default = 5 }
+
+[[testcases]]
+name = "prometheus3"
+instances = { min = 1, max = 200, default = 5 }

--- a/plans/example/go.mod
+++ b/plans/example/go.mod
@@ -10,4 +10,5 @@ replace (
 require (
 	github.com/ipfs/testground/sdk/runtime v0.1.0
 	github.com/ipfs/testground/sdk/sync v0.1.0
+	github.com/prometheus/client_golang v1.4.1
 )

--- a/plans/example/main.go
+++ b/plans/example/main.go
@@ -29,6 +29,8 @@ func run(runenv *runtime.RunEnv) error {
 		return ExamplePrometheus(runenv)
 	case "prometheus2":
 		return ExamplePrometheus2(runenv)
+	case "prometheus3":
+		return ExamplePrometheus3(runenv)
 	default:
 		msg := fmt.Sprintf("Unknown Testcase %s", c)
 		return errors.New(msg)

--- a/plans/example/prometheus_3.go
+++ b/plans/example/prometheus_3.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	counter  prometheus.Counter
+	counter2 prometheus.Counter
+	stage1   prometheus.Histogram
+	stage2   prometheus.Histogram
+	stage3   prometheus.Histogram
+)
+
+func ExamplePrometheus3(runenv *runtime.RunEnv) error {
+	rand.Seed(time.Now().UnixNano())
+
+	counter = runtime.NewCounter(runenv, "anton_counter", "")
+	counter2 = runtime.NewCounter(runenv, "anton_counter2", "")
+	stage1 = runtime.NewHistogram(runenv, "anton_stage1_timer", "")
+	stage2 = runtime.NewHistogram(runenv, "anton_stage2_timer", "")
+	stage3 = runtime.NewHistogram(runenv, "anton_stage3_timer", "")
+
+	// run test
+
+	executeStage(100, 50, stage1)
+
+	time.Sleep(30 * time.Second)
+
+	executeStage(200, 20, stage2)
+
+	time.Sleep(40 * time.Second)
+
+	executeStage(500, 50, stage3)
+
+	time.Sleep(20 * time.Second)
+
+	executeCounterStep()
+
+	return nil
+}
+
+func executeStage(initialLatency int, jitter int, s prometheus.Histogram) {
+	var wg sync.WaitGroup
+	wg.Add(100)
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			defer wg.Done()
+			latency := initialLatency + rand.Intn(jitter)
+
+			start := time.Now()
+
+			time.Sleep(time.Duration(latency) * time.Millisecond)
+
+			s.Observe(float64(time.Since(start)))
+			counter.Inc()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func executeCounterStep() {
+	for i := 0; i < 100; i++ {
+		counter2.Inc()
+		time.Sleep(2 * time.Second)
+	}
+}


### PR DESCRIPTION
This PR is adding a set of very simple measurements:
1. Counter that gets incremented once every 2 seconds.
2. Three stages with 100 calls to a function that has latency around 100ms, 200ms and 500ms

We should have an example dashboard on how to visualise those, so that developers using Testground know how to use the `runenv` metrics SDK and how to visualise the results.

- [ ] visualise a counter
- [ ] visualise a 95%ile, 99%ile and mean for the 3 stages
- [ ] visualise all the metrics above grouped by a number of different testrun instances and testrun ids - we can start with 10 or 50 instances, but we have to think how we are going to aggregate when we have 1k and 10k instances and multiple testruns.

cc @coryschwartz 