### PR TITLE
remove time.Sleep; fix coordination between k8s-sidecar

### DIFF
--- a/pkg/dockermanager/dockermanager.go
+++ b/pkg/dockermanager/dockermanager.go
@@ -163,7 +163,7 @@ func (dm *Manager) Manage(
 			err := worker(cctx, handle)
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
-					handle.S().Warnf("sidecar worker failed: %s", err)
+					handle.S().Debugf("sidecar worker failed: %s", err)
 				} else {
 					handle.S().Errorf("sidecar worker failed: %s", err)
 				}

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/vishvananda/netlink"
@@ -486,6 +487,8 @@ func waitForPodRunningPhase(ctx context.Context, podName string) error {
 			}
 
 			phase = string(pod.Status.Phase)
+
+			time.Sleep(1 * time.Second)
 		}
 	}
 }

--- a/pkg/sidecar/k8s_instance.go
+++ b/pkg/sidecar/k8s_instance.go
@@ -488,6 +488,4 @@ func waitForPodRunningPhase(ctx context.Context, podName string) error {
 			phase = string(pod.Status.Phase)
 		}
 	}
-
-	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/ipfs/testground/issues/414

This is supposed to fix the `time.Sleep` hack I introduced a while ago, so that we make sure that Kubernetes is done getting a `PodIP`, before we mess with container networking with `sidecar`.

This PR makes the assumption that it is `safe` to change the networking after a container is in `Running` phase. I am not 100% sure that Kubernetes is done getting the `PodIP` at that stage, but it probably it.