### PR TITLE
Bitswap tuning version compatibility plan

### DIFF
--- a/manifests/bitswap-tuning.toml
+++ b/manifests/bitswap-tuning.toml
@@ -43,5 +43,6 @@ instances = { min = 2, max = 64, default = 2 }
   request_stagger = { type = "int", desc = "time between each leech's first request", unit = "ms", default = 0}
   file_size = { type = "int", desc = "file size", unit = "bytes", default = 4194304 }
   latency_ms = { type = "int", desc = "latency", unit = "ms", default = 5 }
+  jitter_pct = { type = "int", desc = "jitter as percentage of latency", unit = "%", default = 10 }
   bandwidth_mb = { type = "int", desc = "bandwidth", unit = "Mib", default = 1024 }
   parallel_gen_mb = { type = "int", desc = "maximum allowed size of seed data to generate in parallel", unit = "Mib", default = 100 }

--- a/plans/bitswap-tuning/suites/common.js
+++ b/plans/bitswap-tuning/suites/common.js
@@ -11,21 +11,15 @@ function parseMetrics (data) {
 
     if ((log.event || {}).type === 'metric') {
       const metric = log.event.metric
+      const res = {}
       const parts = metric.name.split(/\//)
-      // [ 'latencyMS:100', 'bandwidthMB:1024', 'run:1', 'seq:2', 'file-size:10485760', 'Seed:1', 'msgs_rcvd' ]
-      if (parts.length !== 7) {
-        throw new Error(`Unexpected metric format ${metric}`)
+      for (const part of parts) {
+        const [k, v] = part.split(':')
+        res[k] = v
       }
+      res.value = metric.value
 
-      const [latencyDef, bandwidthDef, runDef, seqDef, fileSizeDef, nodeTypeDef, metricName] = parts
-      const latencyMS = latencyDef.split(':')[1]
-      const bandwidthMB = bandwidthDef.split(':')[1]
-      const run = runDef.split(':')[1]
-      const seq = seqDef.split(':')[1]
-      const fileSize = fileSizeDef.split(':')[1]
-      const [nodeType, nodeTypeIndex] = nodeTypeDef.split(':')
-
-      metrics.push({ run, seq, latencyMS, bandwidthMB, fileSize, nodeType, nodeTypeIndex, name: metricName, value: metric.value })
+      metrics.push(res)
     }
   }
 
@@ -42,7 +36,7 @@ function groupBy (arr, key) {
   return res
 }
 
-function parseArgs (required, defaults) {
+function parseArgs (required = [], defaults = {}) {
   const res = {}
   const args = process.argv.slice(2)
   for (let i = 0; i < args.length; i++) {
@@ -81,6 +75,7 @@ const lineColors = [
   ['#bbe1fa', '#3282b8', '#0f4c75', '#1b262c'],
   ['#f1bc31', '#e25822', '#b22222', '#7c0a02'],
   ['#64e291', '#a0cc78', '#589167', '#207561'],
+  ['#cc6666', '#aa4444', '#992222', '#660000'],
 ]
 const usedColors = []
 function getLineColor (branch, seeds, leeches) {

--- a/plans/bitswap-tuning/suites/version-compat/aggregate.js
+++ b/plans/bitswap-tuning/suites/version-compat/aggregate.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const { parseMetrics, groupBy } = require('../common')
+const fs = require('fs')
+
+const [,, basePath] = process.argv
+if (!basePath) {
+  throw new Error("usage: node aggregate.js <basepath>")
+}
+
+run()
+
+function run () {
+  const data = fs.readFileSync(0).toString() // STDIN_FILENO = 0
+  const metrics = parseMetrics(data)
+
+  const byGroupName = groupBy(metrics, 'groupName')
+  for (const [groupName, metrics] of Object.entries(byGroupName)) {
+    const byNodeType = groupBy(metrics, 'nodeType')
+    for (const [nodeType, metrics] of Object.entries(byNodeType)) {
+      const byName = groupBy(metrics, 'name')
+      for (const [name, metrics] of Object.entries(byName)) {
+        const byRun = groupBy(metrics, 'run')
+        const points = []
+        for (const runNum of Object.keys(byRun).sort(i => parseInt(i))) {
+          const metrics = byRun[runNum]
+          const byFileSize = groupBy(metrics, 'fileSize')
+          for (const [fileSize, metrics] of Object.entries(byFileSize)) {
+            const average = metrics.reduce((a, m) => a + m.value, 0) / metrics.length
+            points.push([fileSize, average])
+          }
+        }
+        writeResults(groupName, nodeType, name, 'average', points)
+      }
+    }
+  }
+}
+
+function writeResults (groupName, nodeType, name, statName, points) {
+  const filePath = basePath + `.${groupName}.${nodeType}.${name}.${statName}.csv`
+  const content = points.map(p => p.join(',')).join('\n') + '\n'
+  fs.writeFileSync(filePath, content)
+}

--- a/plans/bitswap-tuning/suites/version-compat/chart.js
+++ b/plans/bitswap-tuning/suites/version-compat/chart.js
@@ -1,0 +1,123 @@
+'use strict'
+
+// node chart.js \
+//  -d ./results/bw1024MB-3x3 \
+//  -m time_to_fetch \
+//  -b 1024 \
+//  -l 5 \
+//  -xlabel 'File size (MB)' \
+//  -ylabel 'Time to fetch (s)' \
+//  -xscale '9.53674316e-7' \
+//  -yscale '1e-9' \
+//  && gnuplot ./results/bw1024MB-3x3/time_to_fetch.plot > ./results/bw1024MB-3x3/bw1024MB-3x3.svg
+
+const { parseArgs, getLineColor } = require('../common')
+
+const fs = require('fs')
+const path = require('path')
+
+const args = parseArgs(['d', 'm'], {
+  'l': 5, // latency in ms
+  'b': 1024, // bandwidth in MB
+  'xscale': 1,
+  'yscale': 1
+})
+
+function getPlotfile () {
+  let plotFile = `
+    # Output W3C Scalable Vector Graphics
+    set terminal svg
+
+    # Read comma-delimited data from file
+    set datafile separator comma
+
+    # Put the line labels at the top left
+    set key left
+  `
+
+  if (args.xlabel) {
+    plotFile += `set xlabel '${args.xlabel}'\n`
+  }
+
+  if (args.ylabel) {
+    plotFile += `set ylabel '${args.ylabel}'\n`
+  }
+
+  return plotFile
+}
+
+function run (metricName, latencyMS, bandwidthMB) {
+  let outFiles = parseOutputFiles()
+  outFiles = outFiles.filter((file) => file.name === metricName)
+  outputPlot (metricName, outFiles, latencyMS, bandwidthMB)
+}
+
+// Files are in a directory with subdirs for each branch, eg
+// results/master/...
+// results/mybranch/...
+function parseOutputFiles () {
+  const res = []
+  const dir = args.d
+  const subdirs = fs.readdirSync(dir)
+  for (const subdir of subdirs) {
+    const subdirPath = path.join(dir, subdir)
+    if (fs.lstatSync(subdirPath).isDirectory()) {
+      const files = fs.readdirSync(subdirPath)
+      for (const file of files) {
+        const matches = file.match(/out\.(.+)\.Leech\.(.+)\.average\.csv/)
+        if (matches) {
+          const [, groupName, name] = matches
+          const filePath = path.join(subdirPath, file)
+
+          try {
+            fs.accessSync(filePath)
+            res.push({ label: subdir, groupName, name, filePath })
+          } catch (e) {
+          }
+        }
+      }
+    }
+  }
+  return res
+}
+
+function outputPlot (metricName, outFiles, latencyMS, bandwidthMB) {
+  const scaledCols = `(column(1)*(${args.xscale})):(column(2)*(${args.yscale}))`
+
+  let output = getPlotfile()
+  output += `set title 'Bitswap (${latencyMS}ms latency, ${bandwidthMB}MB bandwidth)'\n`
+
+  const plotArgs = []
+  for (const [i, { label, groupName, filePath }] of outFiles.entries()) {
+    const id = `${label}_${groupName}`.replace(/\-/g, '_')
+
+    const showLine = true //branch === 'master' && seeds > 1
+    const fn = `f${id}(x)`
+
+    if (showLine) {
+      output += `${fn} = a${id}*x + b${id}\n`
+      output += `fit ${fn} '${filePath}' using ${scaledCols} via a${id},b${id}\n`
+      // output += `${fn} = a${id}*x**2 + b${id}*x + c${id}\n`
+      // output += `fit ${fn} '${filePath}' using 1:2 via a${id},b${id},c${id}\n`
+    }
+
+    const lineColor = getLineColor(label)
+    const title = `${label}`
+    plotArgs.push(`'${filePath}' using ${scaledCols} with points title "" lc rgb '${lineColor}' pointtype 3 pointsize 0.5`)
+    // plotArgs.push(`'${filePath}' smooth csplines title "${title}" lc rgb '${lineColor}' linewidth 2`)
+    if (showLine) {
+      plotArgs.push(`${fn} title "${title}" lc rgb '${lineColor}' linewidth 4`)
+    }
+  }
+  const plotCmd = 'plot ' + plotArgs.join(',\\\n  ')
+  output += plotCmd + '\n'
+
+  const filePath = path.join(args.d, `${metricName}.plot`)
+  fs.writeFileSync(filePath, output)
+}
+
+function usage () {
+  console.log("usage: node graph.js -d <directory> -m <metric> -l <latencyMS> -b <bandwidthMB>")
+}
+
+run(args.m, args.l, args.b)

--- a/plans/bitswap-tuning/suites/version-compat/defs/one-leech-two-seeds.js
+++ b/plans/bitswap-tuning/suites/version-compat/defs/one-leech-two-seeds.js
@@ -1,0 +1,56 @@
+module.exports = {
+  "versions": [{
+    "name": "old-bitswap",
+    "ref": "dcfe40e",
+    "testgroundId": "haves_support_no"
+  }, {
+    "name": "master",
+    "ref": "master",
+    "testgroundId": "haves_support_yes"
+  }],
+  "suites": {
+    "old-from-2old": {
+      "seed": [{
+        "count": 2,
+        "version": "old-bitswap"
+      }],
+      "leech": [{
+        "count": 1,
+        "version": "old-bitswap"
+      }]
+    },
+    "master-from-2master": {
+      "seed": [{
+        "count": 2,
+        "version": "master"
+      }],
+      "leech": [{
+        "count": 1,
+        "version": "master"
+      }]
+    },
+    "master-from-2old": {
+      "seed": [{
+        "count": 2,
+        "version": "old-bitswap"
+      }],
+      "leech": [{
+        "count": 1,
+        "version": "master"
+      }]
+    },
+    "master-from-1master,1old": {
+      "seed": [{
+        "count": 1,
+        "version": "old-bitswap"
+      }, {
+        "count": 1,
+        "version": "master"
+      }],
+      "leech": [{
+        "count": 1,
+        "version": "master"
+      }]
+    },
+  }
+}

--- a/plans/bitswap-tuning/suites/version-compat/gentomls.js
+++ b/plans/bitswap-tuning/suites/version-compat/gentomls.js
@@ -1,0 +1,100 @@
+// node gentomls.js -def ./two-thirds-two-seeds-def.js -o /tmp/gentoml --latency_ms=100 --seed_fraction=2/3
+
+const { groupBy, parseArgs } = require('../common')
+
+const fs = require('fs')
+
+const globalTestParams = {
+  latency_ms: 5,
+  bandwidth_mb: 1024,
+  file_size: "1485760",
+  seed_fraction: "",
+  run_count: "1"
+}
+
+const args = parseArgs(['o', 'def'])
+const basePath = args.o
+const def = require(process.cwd() + '/' + args.def)
+
+for (k of Object.keys(globalTestParams)) {
+  if (args[k]) {
+    globalTestParams[k] = args[k]
+  }
+}
+
+const header = `
+[metadata]
+name    = "transfer-versions"
+author  = "dirkmc"
+
+[global]
+plan    = "bitswap-tuning"
+case    = "transfer"
+builder = "docker:go"
+runner  = "local:docker"
+`
+
+function runSuite (name, suite) {
+  const versions = groupBy(def.versions, "name")
+
+  let output = `# ${name}\n`
+  output += header
+
+  const instanceCount = [...suite.seed, ...suite.leech].reduce((a, s) => a + s.count, 0)
+  output += `total_instances = ${instanceCount}\n`
+
+  let seedCount = 0
+  let leechCount = 0
+  const groups = {}
+  for (const seed of suite.seed) {
+    groups[seed.version] = groups[seed.version] || { seeds: 0, leeches: 0 }
+    groups[seed.version].seeds += seed.count
+    seedCount += seed.count
+  }
+  for (const leech of suite.leech) {
+    groups[leech.version] = groups[leech.version] || { seeds: 0, leeches: 0 }
+    groups[leech.version].leeches += leech.count
+    leechCount += leech.count
+  }
+
+  for (const [version, group] of Object.entries(groups)) {
+    versionDef = versions[version][0]
+
+    let params = {
+      seed_count: seedCount,
+      leech_count: leechCount
+    }
+    if (Object.keys(groups).length > 1) {
+      params[versionDef.testgroundId + '_leech_count'] = group.leeches
+    }
+    params = {...globalTestParams, ...params}
+
+    const paramOut = "{" + Object.entries(params).map(([k, v]) => `${k} = "${v}"`).join(', ') + "}"
+
+    output += `\n[[groups]]\n`
+    output += `id = "${versionDef.testgroundId}"\n`
+    output += `instances = { count = ${group.seeds + group.leeches} }\n`
+    output += `\n`
+    output += `  [groups.build]\n`
+    output += `  # ref for ${versionDef.name}\n`
+    output += `  dependencies = [{ module = "github.com/ipfs/go-bitswap", version = "${versionDef.ref}"} ]\n`
+    output += `\n`
+    output += `  [groups.run]\n`
+    output += `  test_params = ${paramOut}\n`
+  }
+  writeFile(name, output)
+}
+
+function writeFile (name, output) {
+  const fsName = name.replace(/[^a-zA-Z0-9-]/g, '_')
+  const filePath = basePath + `/${fsName}.toml`
+  fs.writeFileSync(filePath, output)
+}
+
+function run () {
+  for (const [name, suite] of Object.entries(def.suites)) {
+    runSuite(name, suite)
+  }
+}
+
+run()

--- a/plans/bitswap-tuning/suites/version-compat/run.sh
+++ b/plans/bitswap-tuning/suites/version-compat/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -x
+
+# run.sh /tmp/run1 one-leech-two-seeds/def.js
+
+LATENCY_MS=100
+BANDWIDTH_MB=1024
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+OUTPUT_DIR=$1
+if [ -z "$OUTPUT_DIR" ]; then
+	TIMESTAMP=$(date +%Y-%m-%d-%T)
+	OUTPUT_DIR="/tmp/bitswap-tuning-output/${TIMESTAMP}"
+fi
+
+DEF_JS=$2
+
+mkdir -p $OUTPUT_DIR
+
+# Generate toml files
+node ${SCRIPT_DIR}/gentomls.js -o $OUTPUT_DIR -def $DEF_JS \
+  --latency_ms=$LATENCY_MS \
+  --bandwidth_mb=$BANDWIDTH_MB \
+  --file_size=1048576,2097152,4194304,8388608,16777216,33554432,67108864 \
+  --run_count=5 \
+  --seed_fraction=2/3
+
+# Use each toml to run testground
+RES_DIR="${OUTPUT_DIR}/results"
+FILES=$OUTPUT_DIR/*.toml
+for FILE in $FILES; do
+	# First line is "# title"
+	TITLE=$(head -1 $FILE)
+	TITLE=${TITLE:2}
+
+	LABEL=$TITLE
+	LABEL_DIR="${RES_DIR}/${LABEL}"
+	mkdir -p $LABEL_DIR
+	OUTFILE_CSV_BASE="${LABEL_DIR}/out"
+
+	./testground run c -f $FILE
+	RUN_ID=`ls -lt ~/.testground/local_docker/outputs/bitswap-tuning | head -2 | tail -1 | awk '{print $NF}'`
+	OUTZIP="${OUTPUT_DIR}/${RUN_ID}.zip"
+	./testground collect --runner=local:docker --output=$OUTZIP $RUN_ID
+	unzip $OUTZIP -d $OUTPUT_DIR
+	cat ${OUTPUT_DIR}/${RUN_ID}/*/*/run.out | node $SCRIPT_DIR/aggregate.js $OUTFILE_CSV_BASE
+done
+
+node $SCRIPT_DIR/chart.js -d $RES_DIR -m time_to_fetch -b $BANDWIDTH_MB -l $LATENCY_MS -xlabel 'File size (MB)' -ylabel 'Time to fetch (s)' -xscale '9.53674316e-7' -yscale '1e-9'
+gnuplot $RES_DIR/time_to_fetch.plot > $RES_DIR/time_to_fetch.svg

--- a/plans/bitswap-tuning/test/transfer.go
+++ b/plans/bitswap-tuning/test/transfer.go
@@ -62,7 +62,7 @@ func Transfer(runenv *runtime.RunEnv) error {
 		return err
 	}
 	defer h.Close()
-	runenv.Message("I am %s with addrs: %v", h.ID(), h.Addrs())
+	runenv.RecordMessage("I am %s with addrs: %v", h.ID(), h.Addrs())
 
 	// Get sequence number of this host
 	seq, err := writer.Write(ctx, sync.PeerSubtree, host.InfoFromHost(h))
@@ -184,7 +184,7 @@ func Transfer(runenv *runtime.RunEnv) error {
 						// Generate a file of the given size and add it to the datastore
 						start = time.Now()
 					}
-					runenv.Message("Generating seed data of %d bytes", fileSize)
+					runenv.RecordMessage("Generating seed data of %d bytes", fileSize)
 
 					rootCid, err := setupSeed(ctx, runenv, bsnode, fileSize, int(seedIndex))
 					if err != nil {
@@ -377,7 +377,7 @@ func parseType(ctx context.Context, runenv *runtime.RunEnv, writer *sync.Writer,
 		tpindex = int(grpseq) - 1 - leechCount
 	}
 
-	runenv.Message("I am %s %d %s", grpPrefix+nodetp.String(), tpindex, seqstr)
+	runenv.RecordMessage("I am %s %d %s", grpPrefix+nodetp.String(), tpindex, seqstr)
 
 	return grpseq, nodetp, tpindex, nil
 }
@@ -434,7 +434,7 @@ func setupSeed(ctx context.Context, runenv *runtime.RunEnv, node *utils.Node, fi
 		return cid.Cid{}, err
 	}
 
-	runenv.Message("Retained %d / %d of blocks from seed, removed %d / %d blocks", numerator, denominator, len(del), len(nodes))
+	runenv.RecordMessage("Retained %d / %d of blocks from seed, removed %d / %d blocks", numerator, denominator, len(del), len(nodes))
 	return ipldNode.Cid(), nil
 }
 

--- a/plans/bitswap-tuning/utils/metrics.go
+++ b/plans/bitswap-tuning/utils/metrics.go
@@ -8,27 +8,27 @@ import (
 
 var (
 	MetricTimeToFetch = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/time_to_fetch", id), Unit: "ns", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:time_to_fetch", id), Unit: "ns", ImprovementDir: -1}
 	}
 	MetricMsgsRcvd = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/msgs_rcvd", id), Unit: "messages", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:msgs_rcvd", id), Unit: "messages", ImprovementDir: -1}
 	}
 	MetricDataSent = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/data_sent", id), Unit: "bytes", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:data_sent", id), Unit: "bytes", ImprovementDir: -1}
 	}
 	MetricDataRcvd = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/data_rcvd", id), Unit: "bytes", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:data_rcvd", id), Unit: "bytes", ImprovementDir: -1}
 	}
 	MetricDupDataRcvd = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/dup_data_rcvd", id), Unit: "bytes", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:dup_data_rcvd", id), Unit: "bytes", ImprovementDir: -1}
 	}
 	MetricBlksSent = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/blks_sent", id), Unit: "blocks", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:blks_sent", id), Unit: "blocks", ImprovementDir: -1}
 	}
 	MetricBlksRcvd = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/blks_rcvd", id), Unit: "blocks", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:blks_rcvd", id), Unit: "blocks", ImprovementDir: -1}
 	}
 	MetricDupBlksRcvd = func(id string) *runtime.MetricDefinition {
-		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/dup_blks_rcvd", id), Unit: "blocks", ImprovementDir: -1}
+		return &runtime.MetricDefinition{Name: fmt.Sprintf("%s/name:dup_blks_rcvd", id), Unit: "blocks", ImprovementDir: -1}
 	}
 )


### PR DESCRIPTION
Fixes https://github.com/ipfs/testground/issues/435

Test plan to verify that new bitswap can pull from old bitswap nodes.

This plan creates a leech pulling from two seed nodes, where each seed has two thirds of the blocks. The leech / seed combinations are:
- old <- two old
- master <- two master
- master <- two old
- master <- one old & one master

<img width="612" alt="Screen Shot 2020-03-04 at 4 24 17 PM" src="https://user-images.githubusercontent.com/169124/75924911-c6cfb480-5e35-11ea-86f2-d54633e657a3.png">

As expected, it appears that master fetching from old bitswap nodes performs slightly more slowly than an old bitswap node fetching from old bitswap nodes (because old bitswap nodes don't support the DONT_HAVE message so it must be simulated with timeouts). 

However master does appear to be more consistent - note the cluster of red points at 32MB, showing that when an old bitswap leech pulls from two old bitswap seeds it is slow for that file size (inconsistent results at 32MB have been noted in other test plans for old bitswap)