### PR TITLE
ensure panics make it to std.err output artifact.

### DIFF
--- a/manifests/placebo.toml
+++ b/manifests/placebo.toml
@@ -51,3 +51,8 @@ instances = { min = 1, max = 250, default = 1 }
 
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
+
+# seq 3
+[[testcases]]
+name = "panic"
+instances = { min = 1, max = 250, default = 1 }

--- a/plans/placebo/main.go
+++ b/plans/placebo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -36,6 +37,9 @@ func run(runenv *runtime.RunEnv) error {
 
 		time.Sleep(time.Second * 10)
 		return nil
+	case 3:
+		// panic
+		panic(errors.New("this is an intentional panic"))
 	default:
 		return fmt.Errorf("aborting")
 	}

--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 )
@@ -86,8 +87,12 @@ func Invoke(tc func(*RunEnv) error) {
 	// Prepare the event.
 	defer func() {
 		if err := recover(); err != nil {
-			// Handle panics.
+			// Handle panics by recording them in the runenv output.
 			runenv.RecordCrash(err)
+
+			// Developers expect panics to be recorded in run.err too.
+			fmt.Fprintln(os.Stderr, err)
+			debug.PrintStack()
 		}
 	}()
 


### PR DESCRIPTION
Fixes https://github.com/ipfs/testground/issues/674.