### PR TITLE
local docker prometheus

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -86,7 +86,6 @@ github.com/docker/docker v1.4.2-0.20191127125652-7c3d53ed640f h1:5YWFnInM4qyKQFT
 github.com/docker/docker v1.4.2-0.20191127125652-7c3d53ed640f/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde h1:xtjCZeAaT6ywXdjmvJMdbOESh8buEkoTnsLViZAjI8U=
 github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,7 @@ github.com/docker/docker v1.4.2-0.20191127125652-7c3d53ed640f h1:5YWFnInM4qyKQFT
 github.com/docker/docker v1.4.2-0.20191127125652-7c3d53ed640f/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde h1:xtjCZeAaT6ywXdjmvJMdbOESh8buEkoTnsLViZAjI8U=
 github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,1 @@
+# Docker images for use in the local:docker environment.

--- a/infra/docker/testground-prometheus/Dockerfile
+++ b/infra/docker/testground-prometheus/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus
+
+COPY prometheus.yml /etc/prometheus.yml

--- a/infra/docker/testground-prometheus/prometheus.yml
+++ b/infra/docker/testground-prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval:     5s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+    - targets: ['localhost:9090']
+
+  - job_name: 'prometheus-pushgateway'
+    static_configs:
+      - targets: ['prometheus-pushgateway:9090']
+
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['testground-redis']

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -26,7 +26,6 @@ func defaultBuildOptsFor(name string) *types.ImageBuildOptions {
 		Remove:         true,
 		ForceRemove:    true,
 		PullParent:     true,
-		Dockerfile:     "/Dockerfile",
 		Tags:           []string{name},
 	}
 }

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -588,7 +588,7 @@ func ensureControlNetwork(ctx context.Context, cli *client.Client, log *zap.Suga
 		ctx,
 		log, cli,
 		"testground-control",
-		true,
+		false,
 		network.IPAMConfig{
 			Subnet:  controlSubnet,
 			Gateway: controlGateway,
@@ -642,7 +642,8 @@ func ensureInfraContainer(ctx context.Context, cli *client.Client, log *zap.Suga
 			Image: imageName,
 		},
 		HostConfig: &container.HostConfig{
-			NetworkMode: container.NetworkMode(NetworkID),
+			NetworkMode:     container.NetworkMode(NetworkID),
+			PublishAllPorts: true,
 		},
 		PullImageIfMissing: pull,
 	})

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -263,7 +263,7 @@ func (r *LocalDockerRunner) Healthcheck(fix bool, engine api.Engine, writer io.W
 			it := api.HealthcheckItem{Name: "prometheus-container", Status: api.HealthcheckStatusOmitted, Message: msg}
 			fixes = append(fixes, it)
 		default:
-			_, err := docker.EnsureImage(ctx, log, cli, &docker.EnsureImageOpts{
+			_, err := docker.EnsureImage(ctx, log, cli, &docker.BuildImageOpts{
 				Name: "testground-prometheus",
 				// the Source dir is available as a BuildInput, but I don't have access to this very easily
 				// in the health check

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -269,7 +269,7 @@ func (r *LocalDockerRunner) Healthcheck(fix bool, engine api.Engine, writer io.W
 				// in the health check
 				// Find the location of infra somehow.
 				// TODO:
-				BuildCtx: "/home/cory/code/testground/infra/docker/testground-prometheus",
+				BuildCtx: "/home/cory/go/src/github.com/ipfs/testground/infra/docker/testground-prometheus",
 			})
 			if err == nil {
 				_, err := ensureInfraContainer(ctx, cli, log, "testground-prometheus", "testground-prometheus:latest", r.controlNetworkID, false)

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -265,12 +265,10 @@ func (r *LocalDockerRunner) Healthcheck(fix bool, engine api.Engine, writer io.W
 		default:
 			_, err := docker.EnsureImage(ctx, log, cli, &docker.BuildImageOpts{
 				Name: "testground-prometheus",
-				// the Source dir is available as a BuildInput, but I don't have access to this very easily
-				// in the health check
-				// Find the location of infra somehow.
-				// TODO:
-				BuildCtx: "/home/cory/go/src/github.com/ipfs/testground/infra/docker/testground-prometheus",
+				// This is the location of the pre-configured prometheus used by the local docker runner.
+				BuildCtx: strings.Join([]string{engine.EnvConfig().SrcDir, "infra/docker/testground-prometheus"}, "/"),
 			})
+
 			if err == nil {
 				_, err := ensureInfraContainer(ctx, cli, log, "testground-prometheus", "testground-prometheus:latest", r.controlNetworkID, false)
 				if err == nil {

--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -25,6 +25,7 @@ type DockerReactor struct {
 
 func NewDockerReactor() (Reactor, error) {
 	// TODO: Generalize this to a list of services.
+	// TODO(cory): prometheus-pushgateway could be added as an env variable as well.
 	wantedRoutes := []string{
 		os.Getenv(EnvRedisHost),
 		"prometheus-pushgateway",
@@ -201,7 +202,7 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 			return nil, fmt.Errorf("failed to list routes for link %s", link.Attrs().Name)
 		}
 
-		// Add specific routes to redis if redis uses this link.
+		// Add learned routes plan containers so they can reach  the testground infra on the control network.
 		for _, route := range controlRoutes {
 			if route.LinkIndex != link.Attrs().Index {
 				continue
@@ -209,7 +210,6 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 			if err := netlinkHandle.RouteAdd(&route); err != nil {
 				return nil, fmt.Errorf("failed to add new route: %w", err)
 			}
-			break
 		}
 
 		// Remove the original routes


### PR DESCRIPTION
This is not yet complete, but you can see where it's going.

The prometheus endpoint comes pre-configured with a scraper for the pushgateway, just like it does with the prometheus-operator on kuberntes. It accomplishes this by building a new image with the desired configuration built in.

This builds upon https://github.com/ipfs/testground/pull/681 and depends on it.

Right now there's something I'm doing something wrong with setting up the routes, and I'll have to fix that later.

issue: https://github.com/ipfs/testground/issues/660