### PR TITLE
dont be a terminal

### DIFF
--- a/pkg/docker/output.go
+++ b/pkg/docker/output.go
@@ -16,7 +16,7 @@ Loop:
 	for dec := json.NewDecoder(r); ; {
 		switch err := dec.Decode(&msg); err {
 		case nil:
-			_ = msg.Display(w, true)
+			_ = msg.Display(w, false)
 			if msg.Error != nil {
 				return msg.Error
 			}


### PR DESCRIPTION
Don't try to send fancy terminal output.

1. It doesn't work that well. Docker command output is sometimes multi-line progress bars, which get squashed when output the way we print it now.

2. Even if it did work well, we might not want it. The output should be scroll-able -- more like a log, and should not include terminal escape sequences, cursor movements, beeps, colors, clears, etc.

