### PR TITLE
Revert "build with go 1.14 in CI (#638)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/gopath/pkg/mod
 
 go:
-  - 1.14.x
+  - 1.13.x
 
 services:
   - docker

--- a/dashboards/main.go
+++ b/dashboards/main.go
@@ -88,7 +88,7 @@ func ImportDatasources(c *sdk.Client) {
 				}
 			}
 			if status, err = c.CreateDatasource(newDS); err != nil {
-				fmt.Fprint(os.Stderr, fmt.Sprintf("error on importing datasource %s with %s (%s)", newDS.Name, err, *status.Message))
+				fmt.Fprintf(os.Stderr, "error on importing datasource %s with %s (%s)", newDS.Name, err, *status.Message)
 			}
 		}
 	}

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -183,9 +183,9 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output 
 
 	// Inject replace directives for the SDK modules.
 	replaces = append(replaces,
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/sync=../sdk/sync"),
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/iptb=../sdk/iptb"),
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/runtime=../sdk/runtime"))
+		"-replace=github.com/ipfs/testground/sdk/sync=../sdk/sync",
+		"-replace=github.com/ipfs/testground/sdk/iptb=../sdk/iptb",
+		"-replace=github.com/ipfs/testground/sdk/runtime=../sdk/runtime")
 
 	// Write replace directives.
 	cmd := exec.CommandContext(ctx, "go", append([]string{"mod", "edit"}, replaces...)...)

--- a/pkg/build/golang/exec.go
+++ b/pkg/build/golang/exec.go
@@ -104,9 +104,9 @@ func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output
 
 	// Inject replace directives for the SDK modules.
 	replaces = append(replaces,
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/sync=../sdk/sync"),
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/iptb=../sdk/iptb"),
-		fmt.Sprintf("-replace=github.com/ipfs/testground/sdk/runtime=../sdk/runtime"))
+		"-replace=github.com/ipfs/testground/sdk/sync=../sdk/sync",
+		"-replace=github.com/ipfs/testground/sdk/iptb=../sdk/iptb",
+		"-replace=github.com/ipfs/testground/sdk/runtime=../sdk/runtime")
 
 	// Write replace directives.
 	cmd := exec.CommandContext(ctx, "go", append([]string{"mod", "edit"}, replaces...)...)

--- a/plans/benchmarks/go.mod
+++ b/plans/benchmarks/go.mod
@@ -8,22 +8,9 @@ replace (
 )
 
 require (
-	github.com/ipfs/go-ipfs-blockstore v1.0.0 // indirect
-	github.com/ipfs/testground/plans/bitswap-tuning v0.0.0-20200309171004-a86f5504315d // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/ipfs/testground/sdk/runtime v0.2.0
 	github.com/ipfs/testground/sdk/sync v0.2.0
-	github.com/libp2p/go-conn-security v0.1.0 // indirect
-	github.com/libp2p/go-libp2p v6.0.23+incompatible // indirect
-	github.com/libp2p/go-libp2p-host v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-interface-connmgr v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-interface-pnet v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-metrics v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-net v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-protocol v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-transport v0.1.0 // indirect
+	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/prometheus/client_golang v1.4.1
-	github.com/whyrusleeping/go-smux-multiplex v3.0.16+incompatible // indirect
-	github.com/whyrusleeping/go-smux-multistream v2.0.2+incompatible // indirect
-	github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible // indirect
-	github.com/whyrusleeping/yamux v1.2.0 // indirect
 )


### PR DESCRIPTION
This reverts commit 8d58fcab86336cc3bcaf9785e58a23940573f863.

Running into some errors, that I think are caused by the CI go versions.

https://github.com/ipfs/testground/pull/689 to upgrade to 1.14 in more places, but it's currently failing CI also, so for now I want to revert this.