### PR TITLE
Explicit AWS region in install script

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -56,7 +56,7 @@ echo
 
 echo "Install EFS..."
 
-vpcId=`aws ec2 describe-vpcs --filters Name=tag:Name,Values=$NAME --output text | awk '/VPCS/ { print $8 }'`
+vpcId=`aws ec2 describe-vpcs --region=$AWS_REGION --filters Name=tag:Name,Values=$NAME --output text | awk '/VPCS/ { print $8 }'`
 
 if [[ -z ${vpcId} ]]; then
   echo "Couldn't detect AWS VPC created by `kops`"

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -65,7 +65,7 @@ fi
 
 echo "Detected VPC: $vpcId"
 
-securityGroupId=`aws ec2 describe-security-groups --output text | awk '/nodes.'$NAME'/ && /SECURITYGROUPS/ { print $6 };'`
+securityGroupId=`aws ec2 describe-security-groups --region=$AWS_REGION --output text | awk '/nodes.'$NAME'/ && /SECURITYGROUPS/ { print $6 };'`
 
 if [[ -z ${securityGroupId} ]]; then
   echo "Couldn't detect AWS Security Group created by `kops`"
@@ -74,7 +74,7 @@ fi
 
 echo "Detected Security Group ID: $securityGroupId"
 
-subnetId=`aws ec2 describe-subnets --output text | awk '/'$vpcId'/ { print $12 }'`
+subnetId=`aws ec2 describe-subnets --region=$AWS_REGION --output text | awk '/'$vpcId'/ { print $12 }'`
 
 if [[ -z ${subnetId} ]]; then
   echo "Couldn't detect AWS Subnet created by `kops`"


### PR DESCRIPTION
If you have specified the ~~AWS_ZONE~~ AWS_REGION to something other than the default, kops will create the cluster that is undetectable later. Lets specify --region on all aws commands.