### PR TITLE
consistent path for testground outputs

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -495,9 +495,12 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 		VersionedParams(&v1.PodExecOptions{
 			Container: "collect-outputs",
 			Command: []string{
-				"sh",
-				"-c",
-				"cd /outputs && tar -czf - " + input.RunID,
+				"tar",
+				"-C",
+				"/outputs",
+				"-czf",
+				"-",
+				input.RunID,
 			},
 			Stdin:  false,
 			Stderr: false,

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -496,17 +496,16 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 		VersionedParams(&v1.PodExecOptions{
 			Container: "collect-outputs",
 			Command: []string{
-				"tar",
-				"-czf",
-				"-",
-				outputPath,
+				"sh",
+				"-c",
+				"cd /outputs && tar -czf - " + input.RunID,
 			},
 			Stdin:  false,
 			Stderr: false,
 			Stdout: true,
 		}, scheme.ParameterCodec)
 
-	log.Info("Sending command to remote server: ", req.URL())
+	log.Debug("sending command to remote server: ", req.URL())
 	exec, err := remotecommand.NewSPDYExecutor(k8sCfg, "POST", req.URL())
 	if err != nil {
 		log.Warnf("failed to send remote collection command: %v", err)

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -481,8 +481,7 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 	// tar, compress, and write to stdout.
 	// stdout will remain connected so we can read it later.
 
-	outputPath := "/outputs/" + input.RunID
-	log.Info("collecting outputs from ", outputPath)
+	log.Info("collecting outputs")
 
 	req := client.
 		CoreV1().


### PR DESCRIPTION
Currently for `cluster:k8s` we create a tar with the `/outputs/RUN_ID/COMPOSITION/...` structure, whereas other runners create it with `/RUN_ID/COMPOSITION/...`.

This PR is fixing this.