### PR TITLE
add build and push step timers

### DIFF
--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -223,10 +223,14 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output 
 		BuildOpts: &opts,
 	}
 
+	buildStart := time.Now()
+
 	err = docker.BuildImage(ctx, cli, &imageOpts)
 	if err != nil {
 		return nil, err
 	}
+
+	log.Debugw("build completed", "took", time.Since(buildStart))
 
 	deps, err := parseDependenciesFromDocker(ctx, log, cli, in.BuildID)
 	if err != nil {
@@ -239,6 +243,8 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output 
 	}
 
 	if cfg.PushRegistry {
+		pushStart := time.Now()
+		defer func() { log.Debugw("push completed", "took", time.Since(pushStart)) }()
 		if cfg.RegistryType == "aws" {
 			err := pushToAWSRegistry(ctx, log, cli, in, out)
 			return out, err


### PR DESCRIPTION
These 2 steps are rather important for our feedback loop, so it'd be nice to log how long they take and build intuition in case something is wrong, once we start building more complex compositions.