### PR TITLE
sync: barriers - decrease polling frequency to 1s.

### DIFF
--- a/sdk/sync/watch.go
+++ b/sdk/sync/watch.go
@@ -111,7 +111,7 @@ func (w *Watcher) Barrier(ctx context.Context, state State, required int64) <-ch
 		var (
 			last   int64
 			err    error
-			ticker = time.NewTicker(250 * time.Millisecond)
+			ticker = time.NewTicker(1 * time.Second)
 			k      = state.Key(w.root)
 			client = w.client.WithContext(ctx)
 		)


### PR DESCRIPTION
See https://github.com/ipfs/testground/issues/663#issuecomment-601156701.