### PR TITLE
shadow group var

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -217,6 +217,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 		}
 		for i := 0; i < g.Instances; i++ {
 			i := i
+			g := g
 			sem <- struct{}{}
 
 			podName := fmt.Sprintf("%s-%s-%s-%d", jobName, input.RunID, g.ID, i)
@@ -259,6 +260,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 	for _, g := range input.Groups {
 		for i := 0; i < g.Instances; i++ {
 			i := i
+			g := g
 			sem <- struct{}{}
 
 			gg.Go(func() error {


### PR DESCRIPTION
`g` is currently not shadowed, so the closures use incorrect group, resulting in wrong `OUTPUTS` path env var and wrong calls to `kubectl get logs`.

---

I never noticed that because locally I test with a single group, this was noticed by @aschmahmann when running a composition with multiple groups.