### PR TITLE
k8s: remove s3 bucket pod

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -121,7 +121,6 @@ kubectl apply -f ./kops-weave/weave.yml \
               -f ./kops-weave/weave-metrics-service.yml \
               -f ./kops-weave/weave-service-monitor.yml \
               -f ./kops-weave/dummy.yml \
-              -f ./kops-weave/s3bucket.yml \
               -f ./sidecar.yaml
 
 echo "Install Redis..."


### PR DESCRIPTION
Currently after creating a cluster from `install.sh` we get:

```
NAME                                      READY   STATUS                       RESTARTS   AGE
dummy-5z8rk                               1/1     Running                      0          11m
dummy-kr6n2                               1/1     Running                      0          11m
dummy-rq45d                               1/1     Running                      0          11m
efs-provisioner-67884fbc9-8jzzm           1/1     Running                      0          11m
prometheus-pushgateway-77c74c469d-z2r85   1/1     Running                      0          10m
redis-master-0                            2/2     Running                      0          10m
s3bucket-lgrpr                            0/1     CreateContainerConfigError   0          11m
s3bucket-nk5mp                            0/1     CreateContainerConfigError   0          11m
s3bucket-qjqwl                            0/1     CreateContainerConfigError   0          11m
testground-sidecar-gppvx                  1/1     Running                      0          11m
testground-sidecar-mts4b                  1/1     Running                      0          11m
testground-sidecar-q8q2h                  1/1     Running                      0          11m
```

---

Looks like `s3bucket` got in during a rebase/merge as I am pretty sure it was removed with the EFS branch.

In any case it is not a critical problem, but we shouldn't be trying to create this DaemonSet, now that we use EFS to `outputs`.