### PR TITLE
disable transparent huge pages support in kernel

### DIFF
--- a/infra/k8s/kops-weave/dummy.yml
+++ b/infra/k8s/kops-weave/dummy.yml
@@ -16,8 +16,18 @@ spec:
       labels:
         name: dummy
     spec:
+      volumes:
+      - name: host-sys
+        hostPath:
+          path: /sys
+      initContainers:
+      - name: disable-thp
+        image: busybox
+        volumeMounts:
+          - name: host-sys
+            mountPath: /host-sys
+        command: ["sh", "-c", "echo never >/host-sys/kernel/mm/transparent_hugepage/enabled"]
       containers:
       - name: dummy
         command: ["/bin/sleep", "3650d"]
         image: governmentpaas/curl-ssl
-


### PR DESCRIPTION
This is disabling THP, as we are running Redis on one of these hosts:

```
1:M 20 Mar 2020 12:55:31.928 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
```