### PR TITLE
sync service: add Prometheus metrics, refactor metrics, fix related stuff

### DIFF
--- a/infra/docker/testground-prometheus/Dockerfile
+++ b/infra/docker/testground-prometheus/Dockerfile
@@ -1,3 +1,3 @@
 FROM prom/prometheus
 
-COPY prometheus.yml /etc/prometheus.yml
+COPY ./prometheus.yml /etc/prometheus/prometheus.yml

--- a/infra/docker/testground-prometheus/prometheus.yml
+++ b/infra/docker/testground-prometheus/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval:     5s
+  scrape_interval: 5s
 
 scrape_configs:
   - job_name: 'prometheus'
@@ -8,7 +8,7 @@ scrape_configs:
 
   - job_name: 'prometheus-pushgateway'
     static_configs:
-      - targets: ['prometheus-pushgateway:9090']
+      - targets: ['prometheus-pushgateway:9091']
 
   - job_name: 'redis'
     static_configs:

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -74,13 +74,13 @@ func EnsureImage(ctx context.Context, log *zap.SugaredLogger, client *client.Cli
 	for _, image := range images {
 		for _, rt := range image.RepoTags {
 			if strings.HasPrefix(rt, opts.Name) {
-				log.Info("found existing image: %s. continuing.", rt)
+				log.Info("found existing image: %s; continuing", rt)
 				return false, nil
 			}
 		}
 	}
 
-	log.Info("image %s not found. creating new image.", opts.Name)
+	log.Infof("image %s not found; building", opts.Name)
 	err = BuildImage(ctx, client, opts)
 	if err != nil {
 		log.Warn(err)

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -74,7 +74,7 @@ func EnsureImage(ctx context.Context, log *zap.SugaredLogger, client *client.Cli
 	for _, image := range images {
 		for _, rt := range image.RepoTags {
 			if strings.HasPrefix(rt, opts.Name) {
-				log.Info("found existing image: %s; continuing", rt)
+				log.Infof("found existing image: %s; continuing", rt)
 				return false, nil
 			}
 		}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -271,7 +271,7 @@ func (r *LocalDockerRunner) Healthcheck(fix bool, engine api.Engine, writer io.W
 			_, err := docker.EnsureImage(ctx, log, cli, &docker.BuildImageOpts{
 				Name: "testground-prometheus",
 				// This is the location of the pre-configured prometheus used by the local docker runner.
-				BuildCtx: strings.Join([]string{engine.EnvConfig().SrcDir, "infra/docker/testground-prometheus"}, "/"),
+				BuildCtx: filepath.Join(engine.EnvConfig().SrcDir, "infra/docker/testground-prometheus"),
 			})
 
 			if err == nil {

--- a/plans/benchmarks/benchmarks.go
+++ b/plans/benchmarks/benchmarks.go
@@ -31,7 +31,7 @@ func StartTimeBench(runenv *runtime.RunEnv) error {
 	elapsed := time.Since(runenv.TestStartTime)
 	emitTime(runenv, "Time to start", elapsed)
 
-	gauge := runtime.NewGauge(runenv, "start_time", "time from plan scheduled to plan booted")
+	gauge := runenv.M().NewGauge(runtime.GaugeOpts{Name: "start_time", Help: "time from plan scheduled to plan booted"})
 	gauge.Set(float64(elapsed))
 	return nil
 }
@@ -60,7 +60,7 @@ func NetworkInitBench(runenv *runtime.RunEnv) error {
 	elapsed := time.Since(startupTime)
 	emitTime(runenv, "Time to network init", elapsed)
 
-	gauge := runtime.NewGauge(runenv, "net_init_time", "Time waiting for network initialization")
+	gauge := runenv.M().NewGauge(runtime.GaugeOpts{Name: "net_init_time", Help: "Time waiting for network initialization"})
 	gauge.Set(float64(elapsed))
 	return nil
 }
@@ -117,7 +117,7 @@ func NetworkLinkShapeBench(runenv *runtime.RunEnv) error {
 	}
 	duration := time.Since(beforeNetConfig)
 	emitTime(runenv, "Time to configure link shape", duration)
-	gauge := runtime.NewGauge(runenv, "link_shape_time", "time waiting for change in network link shape")
+	gauge := runenv.M().NewGauge(runtime.GaugeOpts{Name: "link_shape_time", Help: "time waiting for change in network link shape"})
 	gauge.Set(float64(duration))
 
 	return nil
@@ -150,7 +150,7 @@ func BarrierBench(runenv *runtime.RunEnv) error {
 		name := fmt.Sprintf("barrier_time_%d_percent", int(percent*100))
 		t := cfg{
 			Name:    name,
-			Gauge:   runtime.NewGauge(runenv, name, fmt.Sprintf("time waiting for %f barrier", percent)),
+			Gauge:   runenv.M().NewGauge(runtime.GaugeOpts{Name: name, Help: fmt.Sprintf("time waiting for %f barrier", percent)}),
 			Percent: percent,
 		}
 		tests = append(tests, &t)
@@ -234,7 +234,7 @@ func SubtreeBench(runenv *runtime.RunEnv) error {
 		Name    string
 		Data    []byte
 		Subtree *sync.Subtree
-		Summary prometheus.Summary
+		Summary runtime.Summary
 	}
 
 	// Create tests ranging from 64B to 64KiB.
@@ -253,7 +253,9 @@ func SubtreeBench(runenv *runtime.RunEnv) error {
 				GroupKey:    name,
 				PayloadType: reflect.TypeOf((*string)(nil)),
 			},
-			Summary: runtime.NewSummary(runenv, name, desc, prometheus.SummaryOpts{
+			Summary: runenv.M().NewSummary(runtime.SummaryOpts{
+				Name:       name,
+				Help:       desc,
 				Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.025, 0.9: 0.01, 0.95: 0.001, 0.99: 0.001},
 			}),
 		}

--- a/plans/dht/test/barrier.go
+++ b/plans/dht/test/barrier.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/ipfs/testground/sdk/sync"
+)
+
+func Barrier(runenv *runtime.RunEnv) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second * 360)
+	defer cancel()
+
+	watcher, writer := sync.MustWatcherWriter(ctx, runenv)
+	defer watcher.Close()
+	defer writer.Close()
+
+	err := SetupNetwork(ctx, runenv, watcher, writer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/plans/example/prometheus.go
+++ b/plans/example/prometheus.go
@@ -7,25 +7,25 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-// the testrgound-ified version of this example:
+// the testground-ified version of this example:
 // https://godoc.org/github.com/prometheus/client_golang/prometheus/push#example-Pusher-Add
 func ExamplePrometheus(runenv *runtime.RunEnv) error {
-	completionTime := runtime.NewGauge(
-		runenv,
-		"db_backup_last_completion_time_seconds",
-		"The timestamp of the last completion of a DB backup, successful or not.")
-	successTime := runtime.NewGauge(
-		runenv,
-		"db_backup_last_success_timestamp_seconds",
-		"The timestamp of the last successful completion of a DB backup.")
-	duration := runtime.NewGauge(
-		runenv,
-		"db_backup_duration_seconds",
-		"The duration of the last DB backup in seconds.")
-	records := runtime.NewGauge(
-		runenv,
-		"db_backup_records_processed",
-		"The number of records processed in the last DB backup.")
+	completionTime := runenv.M().NewGauge(runtime.GaugeOpts{
+		Name: "db_backup_last_completion_time_seconds",
+		Help: "The timestamp of the last completion of a DB backup, successful or not.",
+	})
+	successTime := runenv.M().NewGauge(runtime.GaugeOpts{
+		Name: "db_backup_last_success_timestamp_seconds",
+		Help: "The timestamp of the last successful completion of a DB backup.",
+	})
+	duration := runenv.M().NewGauge(runtime.GaugeOpts{
+		Name: "db_backup_duration_seconds",
+		Help: "The duration of the last DB backup in seconds.",
+	})
+	records := runenv.M().NewGauge(runtime.GaugeOpts{
+		Name: "db_backup_records_processed",
+		Help: "The number of records processed in the last DB backup.",
+	})
 
 	// Notice, you don't have to instantiate the pusher or push data yourself.
 	// This is handled for you by runtime.Invoke()
@@ -75,12 +75,12 @@ func ExamplePrometheus(runenv *runtime.RunEnv) error {
 //
 // For more examples, see https://prometheus.io/docs/prometheus/latest/querying/basics/
 func ExamplePrometheus2(runenv *runtime.RunEnv) error {
-	counter := runtime.NewCounter(runenv, "example_counter", "I count how many times something happens")
-	counter2 := runtime.NewCounter(runenv, "example_counter2", "I count how many times something happens")
-	histogram := runtime.NewHistogram(runenv, "example_histogram", "information in buckets")
-	histogram2 := runtime.NewHistogram(runenv, "example_histogram2", "histogram with non-default buckets", 1.0, 5.0, 6.0)
-	gauge := runtime.NewGauge(runenv, "example_gauge", "values, can go up and down")
-	gauge2 := runtime.NewGauge(runenv, "example_gauge2", "values, can go up and down")
+	counter := runenv.M().NewCounter(runtime.CounterOpts{Name: "example_counter", Help: "I count how many times something happens"})
+	counter2 := runenv.M().NewCounter(runtime.CounterOpts{Name: "example_counter2", Help: "I count how many times something happens"})
+	histogram := runenv.M().NewHistogram(runtime.HistogramOpts{Name: "example_histogram", Help: "information in buckets"})
+	histogram2 := runenv.M().NewHistogram(runtime.HistogramOpts{Name: "example_histogram2", Help: "histogram with non-default buckets", Buckets: []float64{1.0, 5.0, 6.0}})
+	gauge := runenv.M().NewGauge(runtime.GaugeOpts{Name: "example_gauge", Help: "values, can go up and down"})
+	gauge2 := runenv.M().NewGauge(runtime.GaugeOpts{Name: "example_gauge2", Help: "values, can go up and down"})
 	rand.Seed(time.Now().UnixNano())
 
 	// increment the counter once per second

--- a/plans/example/prometheus_3.go
+++ b/plans/example/prometheus_3.go
@@ -10,21 +10,21 @@ import (
 )
 
 var (
-	counter  prometheus.Counter
-	counter2 prometheus.Counter
-	stage1   prometheus.Histogram
-	stage2   prometheus.Histogram
-	stage3   prometheus.Histogram
+	counter  runtime.Counter
+	counter2 runtime.Counter
+	stage1   runtime.Histogram
+	stage2   runtime.Histogram
+	stage3   runtime.Histogram
 )
 
 func ExamplePrometheus3(runenv *runtime.RunEnv) error {
 	rand.Seed(time.Now().UnixNano())
 
-	counter = runtime.NewCounter(runenv, "anton_counter", "")
-	counter2 = runtime.NewCounter(runenv, "anton_counter2", "")
-	stage1 = runtime.NewHistogram(runenv, "anton_stage1_timer", "")
-	stage2 = runtime.NewHistogram(runenv, "anton_stage2_timer", "")
-	stage3 = runtime.NewHistogram(runenv, "anton_stage3_timer", "")
+	counter = runenv.M().NewCounter(runtime.CounterOpts{Name: "anton_counter"})
+	counter2 = runenv.M().NewCounter(runtime.CounterOpts{Name: "anton_counter2"})
+	stage1 = runenv.M().NewHistogram(runtime.HistogramOpts{Name: "anton_stage1_timer"})
+	stage2 = runenv.M().NewHistogram(runtime.HistogramOpts{Name: "anton_stage2_timer"})
+	stage3 = runenv.M().NewHistogram(runtime.HistogramOpts{Name: "anton_stage3_timer"})
 
 	// run test
 

--- a/sdk/runtime/metrics.go
+++ b/sdk/runtime/metrics.go
@@ -12,40 +12,106 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewCounter(runenv *RunEnv, name string, help string) prometheus.Counter {
-	c := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: name,
-		Help: help,
-	})
-	prometheus.MustRegister(c)
-	return c
+// Type aliases to hide implementation details in the APIs.
+type (
+	Counter   = prometheus.Counter
+	Gauge     = prometheus.Gauge
+	Histogram = prometheus.Histogram
+	Summary   = prometheus.Summary
+
+	CounterOpts   = prometheus.CounterOpts
+	GaugeOpts     = prometheus.GaugeOpts
+	HistogramOpts = prometheus.HistogramOpts
+	SummaryOpts   = prometheus.SummaryOpts
+
+	CounterVec   = prometheus.CounterVec
+	GaugeVec     = prometheus.GaugeVec
+	HistogramVec = prometheus.HistogramVec
+	SummaryVec   = prometheus.SummaryVec
+)
+
+type Metrics struct {
+	runenv *RunEnv
 }
 
-func NewGauge(runenv *RunEnv, name string, help string) prometheus.Gauge {
-	g := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: name,
-		Help: help,
-	})
-	prometheus.MustRegister(g)
-	return g
+func (*Metrics) NewCounter(o CounterOpts) Counter {
+	m := prometheus.NewCounter(o)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
 }
 
-func NewHistogram(runenv *RunEnv, name string, help string, buckets ...float64) prometheus.Histogram {
-	h := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    name,
-		Help:    help,
-		Buckets: buckets,
-	})
-	prometheus.MustRegister(h)
-	return h
+func (*Metrics) NewGauge(o GaugeOpts) Gauge {
+	m := prometheus.NewGauge(o)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
 }
 
-func NewSummary(runenv *RunEnv, name string, help string, opts prometheus.SummaryOpts) prometheus.Summary {
-	opts.Name = name
-	opts.Help = help
-	s := prometheus.NewSummary(opts)
-	prometheus.MustRegister(s)
-	return s
+func (*Metrics) NewHistogram(o HistogramOpts) Histogram {
+	m := prometheus.NewHistogram(o)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
+}
+
+func (*Metrics) NewSummary(o SummaryOpts) Summary {
+	m := prometheus.NewSummary(o)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
+}
+
+func (*Metrics) NewCounterVec(o CounterOpts, labels ...string) *CounterVec {
+	m := prometheus.NewCounterVec(o, labels)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
+}
+
+func (*Metrics) NewGaugeVec(o GaugeOpts, labels ...string) *GaugeVec {
+	m := prometheus.NewGaugeVec(o, labels)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
+}
+
+func (*Metrics) NewHistogramVec(o HistogramOpts, labels ...string) *HistogramVec {
+	m := prometheus.NewHistogramVec(o, labels)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
+}
+
+func (*Metrics) NewSummaryVec(o SummaryOpts, labels ...string) *SummaryVec {
+	m := prometheus.NewSummaryVec(o, labels)
+	switch err := prometheus.Register(m); err.(type) {
+	case nil, prometheus.AlreadyRegisteredError:
+	default:
+		panic(err)
+	}
+	return m
 }
 
 // HTTPPeriodicSnapshots periodically fetches the snapshots from the given address

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -101,6 +101,7 @@ type RunEnv struct {
 	RunParams
 	*logger
 
+	metrics      *Metrics
 	unstructured chan *os.File
 	structured   chan *zap.Logger
 }
@@ -114,8 +115,14 @@ func NewRunEnv(params RunParams) *RunEnv {
 		unstructured: make(chan *os.File, 32),
 	}
 
+	re.metrics = &Metrics{re}
 	re.logger = newLogger(&re.RunParams)
 	return re
+}
+
+// M returns an object that groups the metrics facilities.
+func (re *RunEnv) M() *Metrics {
+	return re.metrics
 }
 
 func (re *RunEnv) Close() error {

--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -111,7 +111,10 @@ func Invoke(tc func(*RunEnv) error) {
 // setupMetrics tracks the test duration, and sets up Prometheus metrics push.
 func setupMetrics(ctx context.Context, runenv *RunEnv) (doneCh chan error) {
 	doneCh = make(chan error)
-	testDuration := NewGauge(runenv, "plan_duration", "run time (seconds)")
+	testDuration := runenv.M().NewGauge(prometheus.GaugeOpts{
+		Name: "tg_plan_duration",
+		Help: "test plan run time (seconds)",
+	})
 
 	durationCh := make(chan struct{})
 	// Keep reporting the test duration every second.

--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -178,11 +178,11 @@ func setupMetrics(ctx context.Context, runenv *RunEnv) (doneCh chan error) {
 
 		pusher := push.New(endpoint, "testground/plan").
 			Gatherer(prometheus.DefaultGatherer).
-			Grouping("TestPlan", runenv.TestPlan).
-			Grouping("TestCase", runenv.TestCase).
-			Grouping("TestRun", runenv.TestRun).
-			Grouping("TestGroupID", runenv.TestGroupID).
-			Grouping("ContainerName", hostname)
+			Grouping("plan", runenv.TestPlan).
+			Grouping("case", runenv.TestCase).
+			Grouping("run_id", runenv.TestRun).
+			Grouping("group_id", runenv.TestGroupID).
+			Grouping("container_name", hostname)
 
 		push := func() {
 			if err := pusher.Add(); err != nil {

--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -154,10 +154,7 @@ func setupMetrics(ctx context.Context, runenv *RunEnv) (doneCh chan error) {
 				if err != nil {
 					continue
 				}
-				_, err = resp.Body.Read(b)
-				if err != nil {
-					continue
-				}
+				_, _ = resp.Body.Read(b)
 				if string(b) == "OK" {
 					break Outer
 				}

--- a/sdk/sync/go.mod
+++ b/sdk/sync/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.2.3
 	github.com/libp2p/go-openssl v0.0.4 // indirect
 	github.com/multiformats/go-multiaddr v0.1.1
+	github.com/prometheus/client_golang v1.4.1
 	golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d // indirect
 )
 


### PR DESCRIPTION
This PR:

- refactors the runtime metrics API to make it stem from the runenv: `runenv.M().NewGauge()`.
- modifies the API to tackle Prometheus Opts objects directly, for better flexibility.
- adds CounterVec, GaugeVec, HistogramVec, SummaryVec metrics.
- fixes the Prometheus docker image.
- fixes the Pushgateway liveness check, which got borked in https://github.com/ipfs/testground/commit/c0400ff614dee308e895ccfed3da386d7a385e37#diff-fbfb6e457d5f040c52788ffb0b2a7085R154-R157.
- adds metrics to the sync service, to both the Writer and the Watcher, to monitor barrier and subtree metrics. See #727 for more info.