### PR TITLE
disable TestSidecar

### DIFF
--- a/cmd/itest/sidecar_test.go
+++ b/cmd/itest/sidecar_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestSidecar(t *testing.T) {
+	t.Skip("Skipping flaky test")
+
 	err := runSingle(t,
 		"run",
 		"single",


### PR DESCRIPTION
`TestSidecar` is flaky, we have a bug issue for it for a while: https://github.com/ipfs/testground/issues/325