### PR TITLE
local exec redis exporter

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -141,9 +141,13 @@ You should see a bunch of logs that describe the steps of the test, from:
 
 In order to run the tests with the local:exec runner, there are a few things that must be taken care of first.
 1. install required test software
-  * redis (redis.io)
-  * prometheus (prometheus.io)
-  * prometheus-pushgateway (prometheus.io)
+  * redis (https://redis.io/download)
+  * redis_exporter (https://github.com/oliver006/redis_exporter/releases)
+  * prometheus (https://prometheus.io/download/)
+  * prometheus-pushgateway (https://prometheus.io/download/)
+  * grafana (https://grafana.com/grafana/download)
+
+2. If not installed using your system's package manager, make sure your PATH is adjusted on the testground daemon so the software can be properly started.
 
 (bug) the address of the promethus pushgateway is hard-coded to http://prometheus-pushgateway.
 This works fine on the docker and k8s runners, but you will need to make this address resolvable on your local system.

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -107,6 +107,16 @@ func (r *LocalExecutableRunner) Healthcheck(fix bool, engine api.Engine, writer 
 			"local-pushgateway",
 			"localhost:9091",
 			"pushgateway"),
+		newhealthcheckedProcess(ctx,
+			"local-redis-exporter",
+			"localhost:9121",
+			"redis_exporter",
+		),
+		newhealthcheckedProcess(ctx,
+			"local-grafana",
+			"localhost:3000",
+			"grafana_server",
+		),
 	}
 
 	eg, _ := errgroup.WithContext(ctx)


### PR DESCRIPTION
This is the local:exec equivilent for https://github.com/ipfs/testground/pull/730

With this change, running the local exec runner will be more difficult to use, requiring more third party software to be in the PATH, installed by the user somehow.


From an ease-of-use perspective, we could download third party software for the user.  It would be possible to download grafana, redis, redis_exporter, prometheus, and prometheus_pushgateway into the user's home directory under `~/.testground/thridparty` or some similar location, but this presents its own set of problems to detect the OS and download the appropriate package.

I'm including an entry in the README to point users toward where to download this software on their own. 