### PR TITLE
increase port-forward timeout in kubelet

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -37,6 +37,7 @@ spec:
     allowedUnsafeSysctls:
       - net.core.somaxconn
       - net.netfilter.nf_conntrack_max
+    streamingConnectionIdleTimeout: 60m
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.15.9


### PR DESCRIPTION
This is increasing the timeout for idle connection when doing `kubectl port-forward` - you've probably noticed that the connection to Grafana (and now to `testground daemon` when we start deploying in on k8s) gets killed often - this is most probably why.

Related: https://stackoverflow.com/questions/47484312/kubectl-port-forwarding-timeout-issue