### PR TITLE
move testground services to control network

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -114,8 +114,9 @@ kubectl apply -f ./efs/rbac.yaml \
               -f $EFS_MANIFEST_SPEC
 
 # monitoring and redis.
-echo "installing helm infrastructure"
-helm install testground-infra ./testground-infra
+echo "Installing helm infrastructure"
+helm install --wait --timeout 2m testground-infra ./testground-infra
+sleep 10
 
 echo "Install Weave, CNI-Genie, s3bucket DaemonSet, Sidecar Daemonset..."
 echo

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -17,6 +17,9 @@
 #   See https://github.com/helm/charts/blob/master/stable/prometheus-operator/README.md#L193
 #   for an explanation of this option.
 prometheus-operator:
+  podAnnotations: {
+    cni: "flannel"
+  }
   alertmanager:
     enabled: false
   grafana:
@@ -72,6 +75,9 @@ prometheus-pushgateway:
     namespace: default
   networkPolicy:
     allowAll: true
+  podAnnotations: {
+    cni: "flannel"
+  }
 
 
 # Changes from defaults:
@@ -85,3 +91,7 @@ redis:
       namespace: default
   cluster:
     enabled: false
+  master:
+    podAnnotations: {
+      cni: "flannel"
+    }

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -62,7 +62,7 @@ prometheus-operator:
 # * override "fullname" so it is resolves with http://prometheus-pushgateway
 #   This matches the behavior from the kops addon, but we don't need to do this
 #   once we make this a configurable option.
-# * enable the serviceMonitor, so it will be picked up by the prometheus 
+# * enable the serviceMonitor, so it will be picked up by the prometheus
 #   operator. Move the serviceMonitor to the default namespace.
 # * Change the scrape interval to a short value. This should be set to the same
 #   value with which plans push to the pushgatway. See the runner sdk.
@@ -86,9 +86,10 @@ prometheus-pushgateway:
 redis:
   metrics:
     enabled: true
-    serviceMonitor: 
+    serviceMonitor:
       enabled: true
       namespace: default
+  usePassword: false
   cluster:
     enabled: false
   master:


### PR DESCRIPTION
See `docs/NETWORKING.md`

control network -> flannel
data network -> weave

Generally we should not add auxiliary services to the data network - it is used by the test plans.