### PR TITLE
[bug]restore redis values

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -228,7 +228,7 @@ $ redis-cli -h localhost -p 6379
 7. Get access to Grafana (initial credentials are admin/admin):
 
 ```sh
-$ kubectl -n monitoring port-forward service/grafana 3000:3000
+$ kubectl port-forward service/testground-infra-grafana 3000:80
 ```
 
 ## Use a Kubernetes context for another cluster
@@ -244,7 +244,7 @@ $ kops export kubecfg --state $KOPS_STATE_STORE --name=$NAME
 ## How to access the prometheus web UI (for metrics observability)
 
 ```sh
-$ kubectl -n monitoring port-forward service/prometheus-k8s 9090:9090
+$ kubectl port-forward service/testground-infra-prometheu-prometheus 9090:9090
 ```
 
 Direct your web browser to [http://localhost:9090](http://localhost:9090).

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -55,6 +55,7 @@ prometheus-operator:
         serviceMonitorNamespaceSelector:
           any: true
 
+
 # Changes from defaults:
 # * override "fullname" so it is resolves with http://prometheus-pushgateway
 #   This matches the behavior from the kops addon, but we don't need to do this
@@ -77,6 +78,12 @@ prometheus-pushgateway:
 # Changes from defaults:
 # * enable redis exporter
 # * enable the serviceMonitor so it will be picked up by prometheus
+# * Disable cluster mode -- there are failure modes which could result in
+#   dataloss after acknowledgement.
+# * SecurityContext and sysctlImage provides tuning for redis to provide for 10k
+# * Master resources is setup to be a large value so redis will be mostly
+#   singele-tenant.
+# * podAnnotations is set to flannel to force it to be on the control network.
 redis:
   metrics:
     enabled: true
@@ -85,3 +92,26 @@ redis:
       namespace: default
   cluster:
     enabled: false
+  usePassword: false
+  securityContext:
+    - name: net.core.somaxconn
+      value: 100000
+    - name: net.netfilter.nf_conntrack_max
+      value: 100000
+  master:
+    extraFlags:
+    - "--maxclients 100000"
+    podAnnotations:
+       cni: flannel
+    resources:
+      requests:
+        memory: 13000Mi
+        cpu: 6500m
+  sysctlImage:
+    enabled: true
+    command:
+    - /bin/sh
+    - -c
+    - |
+      sysctl -w net.core.somaxconn=100000 &&
+      sysctl -w net.netfilter.nf_conntrack_max=100000

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -118,9 +118,9 @@ redis:
   securityContext:
     sysctls:
     - name: net.core.somaxconn
-      value: 100000
+      value: "100000"
     - name: net.netfilter.nf_conntrack_max
-      value: 100000
+      value: "100000"
   master:
     extraFlags:
     - "--maxclients 100000"

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -16,7 +16,16 @@
 #   error message about CRDs not being created.
 #   See https://github.com/helm/charts/blob/master/stable/prometheus-operator/README.md#L193
 #   for an explanation of this option.
+# * podAnnotations is set to flannel to force it to be ont he control network.
 prometheus-operator:
+  prometheusOperator:
+    createCustomResource: false
+    admissionWebooks:
+      patch:
+        podAnnotations:
+          cni: flannel
+    podAnnotations:
+      cni: flannel
   alertmanager:
     enabled: false
   grafana:
@@ -26,6 +35,14 @@ prometheus-operator:
         enabled: true
       datasources:
         enabled: true
+    podAnnotations:
+      cni: flannel
+  kube-state-metrics:
+    prometheus:
+      monitor:
+        enabled: true
+    podAnnotations:
+      cni: flannel
   kubeProxy:
     serviceMonitor:
       https: false
@@ -45,10 +62,12 @@ prometheus-operator:
     serviceMonitor:
       insecureSkipVerify: true
       https: false
-  operator:
-    createCustomResource: false
-  prometheusOperator:
-    createCustomResource: false
+  prometheus-node-exporter:
+    prometheus:
+      monitor:
+        enables: true
+    podAnnotations:
+      cni: flannel
   prometheus:
     prometheusSpec:
       spec:
@@ -65,6 +84,7 @@ prometheus-operator:
 # * Change the scrape interval to a short value. This should be set to the same
 #   value with which plans push to the pushgatway. See the runner sdk.
 # * Permissive network policy.
+# * podAnnotations is set to flannel to force it to be ont he control network.
 prometheus-pushgateway:
   fullnameOverride: prometheus-pushgateway
   serviceMonitor:
@@ -73,6 +93,8 @@ prometheus-pushgateway:
     namespace: default
   networkPolicy:
     allowAll: true
+  podAnnotations:
+    cni: flannel
 
 
 # Changes from defaults:
@@ -94,6 +116,7 @@ redis:
     enabled: false
   usePassword: false
   securityContext:
+    sysctls:
     - name: net.core.somaxconn
       value: 100000
     - name: net.netfilter.nf_conntrack_max

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -114,7 +114,6 @@ redis:
     serviceMonitor:
       enabled: true
       namespace: default
-  usePassword: false
   cluster:
     enabled: false
   usePassword: false

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -1,3 +1,4 @@
+---
 # Testground values overrides:
 
 # Changes from defaults:
@@ -18,7 +19,6 @@
 #   https://github.com/helm/charts/blob/master/stable/prometheus-operator/
 #   for an explanation of this option.
 # * podAnnotations is set to flannel to force it to be ont he control network.
----
 prometheus-operator:
   prometheusOperator:
     createCustomResource: false

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -14,9 +14,11 @@
 # * createCustomResource is configured to false. For helm v3, custom resources
 #   are still created. By including this option, users won't see a confusing
 #   error message about CRDs not being created.
-#   See https://github.com/helm/charts/blob/master/stable/prometheus-operator/README.md#L193
+#   See the following for a description of this option:
+#   https://github.com/helm/charts/blob/master/stable/prometheus-operator/
 #   for an explanation of this option.
 # * podAnnotations is set to flannel to force it to be ont he control network.
+---
 prometheus-operator:
   prometheusOperator:
     createCustomResource: false
@@ -79,7 +81,7 @@ prometheus-operator:
 # * override "fullname" so it is resolves with http://prometheus-pushgateway
 #   This matches the behavior from the kops addon, but we don't need to do this
 #   once we make this a configurable option.
-# * enable the serviceMonitor, so it will be picked up by the prometheus 
+# * enable the serviceMonitor, so it will be picked up by the prometheus
 #   operator. Move the serviceMonitor to the default namespace.
 # * Change the scrape interval to a short value. This should be set to the same
 #   value with which plans push to the pushgatway. See the runner sdk.
@@ -109,7 +111,7 @@ prometheus-pushgateway:
 redis:
   metrics:
     enabled: true
-    serviceMonitor: 
+    serviceMonitor:
       enabled: true
       namespace: default
   cluster:
@@ -117,24 +119,16 @@ redis:
   usePassword: false
   securityContext:
     sysctls:
-    - name: net.core.somaxconn
-      value: "100000"
-    - name: net.netfilter.nf_conntrack_max
-      value: "100000"
+      - name: net.core.somaxconn
+        value: "100000"
+      - name: net.netfilter.nf_conntrack_max
+        value: "100000"
   master:
     extraFlags:
-    - "--maxclients 100000"
+      - "--maxclients 100000"
     podAnnotations:
-       cni: flannel
+      cni: flannel
     resources:
       requests:
         memory: 13000Mi
         cpu: 6500m
-  sysctlImage:
-    enabled: true
-    command:
-    - /bin/sh
-    - -c
-    - |
-      sysctl -w net.core.somaxconn=100000 &&
-      sysctl -w net.netfilter.nf_conntrack_max=100000


### PR DESCRIPTION
After merging https://github.com/ipfs/testground/pull/723 there were a few issues noticed.

This PR will restore redis values modifications that were lost when I moved redis into a subchart of the testground-infra chart.

