### PR TITLE
bump up resource requests for pushgateway

### DIFF
--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -75,6 +75,10 @@ prometheus-operator:
       spec:
         serviceMonitorNamespaceSelector:
           any: true
+    resources:
+      requests:
+        memory: 2000Mi
+        cpu: 2000m
 
 
 # Changes from defaults:
@@ -97,6 +101,10 @@ prometheus-pushgateway:
     allowAll: true
   podAnnotations:
     cni: flannel
+  resources:
+    requests:
+      memory: 2000Mi
+      cpu: 2000m
 
 
 # Changes from defaults:


### PR DESCRIPTION
Not sure if this will be good enough to support 10k instances, but it is better than the defaults:

```
    Requests:
      cpu:        100m
```