### PR TITLE
daemon/client: mirror logs from daemon to client.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -111,7 +111,7 @@ func doBuild(c *cli.Context, comp *api.Composition) ([]api.BuildOutput, error) {
 	req := &client.BuildRequest{Composition: *comp}
 	resp, err := cl.Build(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("fatal error from daemon: %s", err)
+		return nil, err
 	}
 	defer resp.Close()
 
@@ -121,7 +121,7 @@ func doBuild(c *cli.Context, comp *api.Composition) ([]api.BuildOutput, error) {
 	case context.Canceled:
 		return nil, fmt.Errorf("interrupted")
 	default:
-		return nil, fmt.Errorf("fatal error from daemon: %w", err)
+		return nil, err
 	}
 
 	for i, out := range res {

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -66,7 +66,7 @@ func collectCommand(c *cli.Context) error {
 		if err == context.Canceled {
 			return fmt.Errorf("interrupted")
 		}
-		return fmt.Errorf("fatal error from daemon: %s", err)
+		return err
 	}
 	defer resp.Close()
 
@@ -75,7 +75,7 @@ func collectCommand(c *cli.Context) error {
 		if err == context.Canceled {
 			return fmt.Errorf("interrupted")
 		}
-		return fmt.Errorf("fatal error from daemon: %s", err)
+		return err
 	}
 	defer file.Close()
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/daemon"
@@ -39,7 +38,7 @@ func describeCommand(c *cli.Context) error {
 	}
 	resp, err := api.Describe(ctx, req)
 	if err != nil {
-		return fmt.Errorf("fatal error from daemon: %s", err)
+		return err
 	}
 	defer resp.Close()
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/urfave/cli"
@@ -26,7 +25,7 @@ func listCommand(c *cli.Context) error {
 
 	resp, err := api.List(ctx)
 	if err != nil {
-		return fmt.Errorf("fatal error from daemon: %s", err)
+		return err
 	}
 	defer resp.Close()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -179,7 +179,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 	case context.Canceled:
 		return fmt.Errorf("interrupted")
 	default:
-		return fmt.Errorf("fatal error from daemon: %w", err)
+		return err
 	}
 
 	defer resp.Close()
@@ -214,7 +214,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 		if err == context.Canceled {
 			return fmt.Errorf("interrupted")
 		}
-		return fmt.Errorf("fatal error from daemon: %s", err)
+		return err
 	}
 	defer file.Close()
 

--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ func main() {
 }
 
 func configureLogging(c *cli.Context) {
-	logging.TerminalMode()
-
 	// The LOG_LEVEL environment variable takes precedence.
 	if level := os.Getenv("LOG_LEVEL"); level != "" {
 		var l zapcore.Level

--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
-	"io"
 	"reflect"
 
 	"github.com/ipfs/testground/pkg/config"
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 // Builder is the interface to be implemented by all builders. A builder takes a
@@ -16,7 +16,7 @@ type Builder interface {
 	ID() string
 
 	// Build performs a build.
-	Build(ctx context.Context, input *BuildInput, output io.Writer) (*BuildOutput, error)
+	Build(ctx context.Context, input *BuildInput, output *tgwriter.TgWriter) (*BuildOutput, error)
 
 	// ConfigType returns the configuration type of this builder.
 	ConfigType() reflect.Type

--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/ipfs/testground/pkg/config"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 // Builder is the interface to be implemented by all builders. A builder takes a
@@ -16,7 +16,7 @@ type Builder interface {
 	ID() string
 
 	// Build performs a build.
-	Build(ctx context.Context, input *BuildInput, output *tgwriter.TgWriter) (*BuildOutput, error)
+	Build(ctx context.Context, input *BuildInput, ow *rpc.OutputWriter) (*BuildOutput, error)
 
 	// ConfigType returns the configuration type of this builder.
 	ConfigType() reflect.Type

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"context"
-	"io"
 
 	"github.com/ipfs/testground/pkg/config"
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 type Engine interface {
@@ -16,11 +16,11 @@ type Engine interface {
 	ListBuilders() map[string]Builder
 	ListRunners() map[string]Runner
 
-	DoBuild(context.Context, *Composition, io.Writer) ([]*BuildOutput, error)
-	DoRun(context.Context, *Composition, io.Writer) (*RunOutput, error)
-	DoCollectOutputs(ctx context.Context, runner string, runID string, w io.Writer) error
-	DoTerminate(ctx context.Context, runner string, w io.Writer) error
-	DoHealthcheck(ctx context.Context, runner string, fix bool, w io.Writer) (*HealthcheckReport, error)
+	DoBuild(context.Context, *Composition, *tgwriter.TgWriter) ([]*BuildOutput, error)
+	DoRun(context.Context, *Composition, *tgwriter.TgWriter) (*RunOutput, error)
+	DoCollectOutputs(ctx context.Context, runner string, runID string, w *tgwriter.TgWriter) error
+	DoTerminate(ctx context.Context, runner string, w *tgwriter.TgWriter) error
+	DoHealthcheck(ctx context.Context, runner string, fix bool, w *tgwriter.TgWriter) (*HealthcheckReport, error)
 
 	EnvConfig() config.EnvConfig
 	Context() context.Context

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/ipfs/testground/pkg/config"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 type Engine interface {
@@ -16,11 +16,11 @@ type Engine interface {
 	ListBuilders() map[string]Builder
 	ListRunners() map[string]Runner
 
-	DoBuild(context.Context, *Composition, *tgwriter.TgWriter) ([]*BuildOutput, error)
-	DoRun(context.Context, *Composition, *tgwriter.TgWriter) (*RunOutput, error)
-	DoCollectOutputs(ctx context.Context, runner string, runID string, w *tgwriter.TgWriter) error
-	DoTerminate(ctx context.Context, runner string, w *tgwriter.TgWriter) error
-	DoHealthcheck(ctx context.Context, runner string, fix bool, w *tgwriter.TgWriter) (*HealthcheckReport, error)
+	DoBuild(context.Context, *Composition, *rpc.OutputWriter) ([]*BuildOutput, error)
+	DoRun(context.Context, *Composition, *rpc.OutputWriter) (*RunOutput, error)
+	DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error
+	DoTerminate(ctx context.Context, runner string, ow *rpc.OutputWriter) error
+	DoHealthcheck(ctx context.Context, runner string, fix bool, ow *rpc.OutputWriter) (*HealthcheckReport, error)
 
 	EnvConfig() config.EnvConfig
 	Context() context.Context

--- a/pkg/api/healthchecker.go
+++ b/pkg/api/healthchecker.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 // Healthchecker is the interface to be implemented by a runner that supports
 // healthchecks and fixes.
 type Healthchecker interface {
-	Healthcheck(fix bool, engine Engine, writer *tgwriter.TgWriter) (*HealthcheckReport, error)
+	Healthcheck(fix bool, engine Engine, ow *rpc.OutputWriter) (*HealthcheckReport, error)
 }
 
 // HealthcheckStatus is an enum that represents

--- a/pkg/api/healthchecker.go
+++ b/pkg/api/healthchecker.go
@@ -2,14 +2,15 @@ package api
 
 import (
 	"fmt"
-	"io"
 	"strings"
+
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 // Healthchecker is the interface to be implemented by a runner that supports
 // healthchecks and fixes.
 type Healthchecker interface {
-	Healthcheck(fix bool, engine Engine, writer io.Writer) (*HealthcheckReport, error)
+	Healthcheck(fix bool, engine Engine, writer *tgwriter.TgWriter) (*HealthcheckReport, error)
 }
 
 // HealthcheckStatus is an enum that represents

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"context"
-	"io"
 	"reflect"
 
 	"github.com/ipfs/testground/pkg/config"
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 // Runner is the interface to be implemented by all runners. A runner takes a
@@ -19,7 +19,7 @@ type Runner interface {
 	ID() string
 
 	// Run runs a test case.
-	Run(ctx context.Context, job *RunInput, outputWriter io.Writer) (*RunOutput, error)
+	Run(ctx context.Context, job *RunInput, output *tgwriter.TgWriter) (*RunOutput, error)
 
 	// ConfigType returns the configuration type of this runner.
 	ConfigType() reflect.Type
@@ -30,7 +30,7 @@ type Runner interface {
 
 	// CollectOutputs gathers the outputs from a run, and produces a zip file
 	// with the contents, writing it to the specified io.Writer.
-	CollectOutputs(context.Context, *CollectionInput, io.Writer) error
+	CollectOutputs(context.Context, *CollectionInput, *tgwriter.TgWriter) error
 }
 
 // RunInput encapsulates the input options for running a test plan.
@@ -98,5 +98,5 @@ type CollectionInput struct {
 // Terminatable is the interface to be implemented by a runner that can be
 // terminated.
 type Terminatable interface {
-	TerminateAll(context.Context) error
+	TerminateAll(context.Context, *tgwriter.TgWriter) error
 }

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/ipfs/testground/pkg/config"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 // Runner is the interface to be implemented by all runners. A runner takes a
@@ -19,7 +19,7 @@ type Runner interface {
 	ID() string
 
 	// Run runs a test case.
-	Run(ctx context.Context, job *RunInput, output *tgwriter.TgWriter) (*RunOutput, error)
+	Run(ctx context.Context, job *RunInput, ow *rpc.OutputWriter) (*RunOutput, error)
 
 	// ConfigType returns the configuration type of this runner.
 	ConfigType() reflect.Type
@@ -30,7 +30,7 @@ type Runner interface {
 
 	// CollectOutputs gathers the outputs from a run, and produces a zip file
 	// with the contents, writing it to the specified io.Writer.
-	CollectOutputs(context.Context, *CollectionInput, *tgwriter.TgWriter) error
+	CollectOutputs(context.Context, *CollectionInput, *rpc.OutputWriter) error
 }
 
 // RunInput encapsulates the input options for running a test plan.
@@ -98,5 +98,5 @@ type CollectionInput struct {
 // Terminatable is the interface to be implemented by a runner that can be
 // terminated.
 type Terminatable interface {
-	TerminateAll(context.Context, *tgwriter.TgWriter) error
+	TerminateAll(context.Context, *rpc.OutputWriter) error
 }

--- a/pkg/build/golang/Dockerfile.template
+++ b/pkg/build/golang/Dockerfile.template
@@ -24,7 +24,7 @@ ENV TESTPLAN_EXEC_PKG ${TESTPLAN_EXEC_PKG}
 ENV PLAN_DIR /plan/
 
 # Optionally install IPFS
-RUN if [ -n "${GO_IPFS_VERSION}" ]; then echo Install IPFS ${GO_IPFS_VERSION} && cd /tmp && wget https://dist.ipfs.io/go-ipfs/v${GO_IPFS_VERSION}/go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz && tar xf go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz; fi
+RUN if [ -n "${GO_IPFS_VERSION}" ]; then echo Install IPFS ${GO_IPFS_VERSION} && cd /tmp && wget --quiet https://dist.ipfs.io/go-ipfs/v${GO_IPFS_VERSION}/go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz && tar xf go-ipfs_v${GO_IPFS_VERSION}_linux-amd64.tar.gz; fi
 RUN touch /tmp/delete_me
 
 # Copy only go.mod files and download deps, in order to leverage Docker caching.

--- a/pkg/build/golang/deps.go
+++ b/pkg/build/golang/deps.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
-	"go.uber.org/zap"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func parseDependencies(raw string) map[string]string {
@@ -38,7 +38,7 @@ func parseDependencies(raw string) map[string]string {
 	return modules
 }
 
-func parseDependenciesFromDocker(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, imageID string) (map[string]string, error) {
+func parseDependenciesFromDocker(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client, imageID string) (map[string]string, error) {
 	res, err := cli.ContainerCreate(ctx, &container.Config{Image: imageID}, nil, nil, "")
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func parseDependenciesFromDocker(ctx context.Context, log *zap.SugaredLogger, cl
 	defer func() {
 		err = cli.ContainerRemove(context.Background(), res.ID, types.ContainerRemoveOptions{Force: true})
 		if err != nil {
-			log.Warnf("error while removing container %s: %v", res.ID, err)
+			ow.Warnf("error while removing container %s: %v", res.ID, err)
 		}
 	}()
 

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/aws"
 	"github.com/ipfs/testground/pkg/docker"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -70,7 +70,7 @@ type DockerGoBuilderConfig struct {
 
 // TODO cache build outputs https://github.com/ipfs/testground/issues/36
 // Build builds a testplan written in Go and outputs a Docker container.
-func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output *tgwriter.TgWriter) (*api.BuildOutput, error) {
+func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.OutputWriter) (*api.BuildOutput, error) {
 	cfg, ok := in.BuildConfig.(*DockerGoBuilderConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected configuration type DockerGoBuilderConfig, was: %T", in.BuildConfig)
@@ -83,7 +83,7 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, output 
 
 	var (
 		id       = in.BuildID
-		log      = output.With("build_id", id)
+		log      = ow.With("build_id", id)
 		cli, err = client.NewClientWithOpts(cliopts...)
 	)
 

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/hashicorp/go-getter"
 	"github.com/otiai10/copy"
-	"go.uber.org/zap"
 )
 
 var (
@@ -83,11 +82,10 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 
 	var (
 		id       = in.BuildID
-		log      = ow.With("build_id", id)
 		cli, err = client.NewClientWithOpts(cliopts...)
 	)
 
-	log.Desugar().Core()
+	ow = ow.With("build_id", id)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
@@ -99,17 +97,17 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 	// The testground-build network is used to connect build services (like the
 	// GOPROXY) to the build container.
 	b.proxyLk.Lock()
-	buildNetworkID, err := docker.EnsureBridgeNetwork(ctx, log, cli, "testground-build", false)
+	buildNetworkID, err := docker.EnsureBridgeNetwork(ctx, ow, cli, "testground-build", false)
 	if err != nil {
-		log.Errorf("error while creating a testground-build network: %s; forcing direct proxy mode", err)
+		ow.Errorf("error while creating a testground-build network: %s; forcing direct proxy mode", err)
 		cfg.GoProxyMode = "direct"
 	}
 
 	// Set up the go proxy wiring. This will start a goproxy container if
 	// necessary, attaching it to the testground-build network.
-	proxyURL, warn := setupGoProxy(ctx, log, cli, buildNetworkID, cfg)
+	proxyURL, warn := setupGoProxy(ctx, ow, cli, buildNetworkID, cfg)
 	if warn != nil {
-		log.Warnf("warning while setting up the go proxy: %s", warn)
+		ow.Warnf("warning while setting up the go proxy: %s", warn)
 	}
 	b.proxyLk.Unlock()
 
@@ -226,14 +224,14 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 
 	buildStart := time.Now()
 
-	err = docker.BuildImage(ctx, cli, &imageOpts)
+	err = docker.BuildImage(ctx, ow, cli, &imageOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Infow("build completed", "took", time.Since(buildStart))
+	ow.Infow("build completed", "took", time.Since(buildStart))
 
-	deps, err := parseDependenciesFromDocker(ctx, log, cli, in.BuildID)
+	deps, err := parseDependenciesFromDocker(ctx, ow, cli, in.BuildID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to list module dependencies; %w", err)
 	}
@@ -245,14 +243,14 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 
 	if cfg.PushRegistry {
 		pushStart := time.Now()
-		defer func() { log.Infow("image push completed", "took", time.Since(pushStart)) }()
+		defer func() { ow.Infow("image push completed", "took", time.Since(pushStart)) }()
 		if cfg.RegistryType == "aws" {
-			err := pushToAWSRegistry(ctx, log, cli, in, out)
+			err := pushToAWSRegistry(ctx, ow, cli, in, out)
 			return out, err
 		}
 
 		if cfg.RegistryType == "dockerhub" {
-			err := pushToDockerHubRegistry(ctx, log, cli, in, out)
+			err := pushToDockerHubRegistry(ctx, ow, cli, in, out)
 			return out, err
 		}
 
@@ -270,7 +268,7 @@ func (*DockerGoBuilder) ConfigType() reflect.Type {
 	return reflect.TypeOf(DockerGoBuilderConfig{})
 }
 
-func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
+func pushToAWSRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
 	// Get a Docker registry authentication token from AWS ECR.
 	auth, err := aws.ECR.GetAuthToken(in.EnvConfig.AWS)
 	if err != nil {
@@ -289,14 +287,14 @@ func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *clie
 
 	// Tag the image under the AWS ECR repository.
 	tag := uri + ":" + in.BuildID
-	log.Infow("tagging image", "tag", tag)
+	ow.Infow("tagging image", "tag", tag)
 	if err = client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {
 		return err
 	}
 
 	// TODO for some reason, this push is way slower than the equivalent via the
 	// docker CLI. Needs investigation.
-	log.Infow("pushing image", "tag", tag)
+	ow.Infow("pushing image", "tag", tag)
 	rc, err := client.ImagePush(ctx, tag, types.ImagePushOptions{
 		RegistryAuth: aws.ECR.EncodeAuthToken(auth),
 	})
@@ -305,7 +303,7 @@ func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *clie
 	}
 
 	// Pipe the docker output to stdout.
-	if err := docker.PipeOutput(rc, os.Stdout); err != nil {
+	if err := docker.PipeOutput(rc, ow.StdoutWriter()); err != nil {
 		return err
 	}
 
@@ -314,11 +312,11 @@ func pushToAWSRegistry(ctx context.Context, log *zap.SugaredLogger, client *clie
 	return nil
 }
 
-func pushToDockerHubRegistry(ctx context.Context, log *zap.SugaredLogger, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
+func pushToDockerHubRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
 	uri := in.EnvConfig.DockerHub.Repo + "/testground"
 
 	tag := uri + ":" + in.BuildID
-	log.Infow("tagging image", "source", out.ArtifactPath, "repo", uri, "tag", tag)
+	ow.Infow("tagging image", "source", out.ArtifactPath, "repo", uri, "tag", tag)
 
 	if err := client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {
 		return err
@@ -341,10 +339,10 @@ func pushToDockerHubRegistry(ctx context.Context, log *zap.SugaredLogger, client
 		return err
 	}
 
-	log.Infow("pushed image", "source", out.ArtifactPath, "tag", tag, "repo", uri)
+	ow.Infow("pushed image", "source", out.ArtifactPath, "tag", tag, "repo", uri)
 
 	// Pipe the docker output to stdout.
-	if err := docker.PipeOutput(rc, os.Stdout); err != nil {
+	if err := docker.PipeOutput(rc, ow.StdoutWriter()); err != nil {
 		return err
 	}
 
@@ -353,11 +351,11 @@ func pushToDockerHubRegistry(ctx context.Context, log *zap.SugaredLogger, client
 	return nil
 }
 
-func setupLocalGoProxyVol(ctx context.Context, log *zap.SugaredLogger, cli *client.Client) (*mount.Mount, error) {
+func setupLocalGoProxyVol(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client) (*mount.Mount, error) {
 	volumeOpts := docker.EnsureVolumeOpts{
 		Name: "testground-goproxy-vol",
 	}
-	vol, _, err := docker.EnsureVolume(ctx, log, cli, &volumeOpts)
+	vol, _, err := docker.EnsureVolume(ctx, ow.SugaredLogger, cli, &volumeOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -374,13 +372,13 @@ func setupLocalGoProxyVol(ctx context.Context, log *zap.SugaredLogger, cli *clie
 //
 // If an error occurs, it is reduced to a warning, and we fall back to direct
 // mode (i.e. no proxy, not even Google's default one).
-func setupGoProxy(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, buildNetworkID string, cfg *DockerGoBuilderConfig) (proxyURL string, warn error) {
+func setupGoProxy(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client, buildNetworkID string, cfg *DockerGoBuilderConfig) (proxyURL string, warn error) {
 	var mnt *mount.Mount
 
 	switch strings.TrimSpace(cfg.GoProxyMode) {
 	case "direct":
 		proxyURL = "direct"
-		log.Debugw("[go_proxy_mode=direct] no goproxy container will be started")
+		ow.Debugw("[go_proxy_mode=direct] no goproxy container will be started")
 
 	case "remote":
 		if cfg.GoProxyURL == "" {
@@ -390,14 +388,14 @@ func setupGoProxy(ctx context.Context, log *zap.SugaredLogger, cli *client.Clien
 		}
 
 		proxyURL = cfg.GoProxyURL
-		log.Infof("[go_proxy_mode=remote] using url: %s", proxyURL)
+		ow.Infof("[go_proxy_mode=remote] using url: %s", proxyURL)
 
 	case "local":
 		fallthrough
 
 	default:
 		proxyURL = "http://testground-goproxy:8081"
-		mnt, warn = setupLocalGoProxyVol(ctx, log, cli)
+		mnt, warn = setupLocalGoProxyVol(ctx, ow, cli)
 		if warn != nil {
 			proxyURL = "direct"
 			warn = fmt.Errorf("encountered an error setting up the goproxy volueme; falling back to go_proxy_mode=direct; err: %w", warn)
@@ -414,7 +412,7 @@ func setupGoProxy(ctx context.Context, log *zap.SugaredLogger, cli *client.Clien
 			},
 			PullImageIfMissing: true,
 		}
-		_, _, warn = docker.EnsureContainer(ctx, log, cli, &containerOpts)
+		_, _, warn = docker.EnsureContainer(ctx, ow, cli, &containerOpts)
 		if warn != nil {
 			proxyURL = "direct"
 			warn = fmt.Errorf("encountered an error when creating the goproxy container; falling back to go_proxy_mode=direct; err: %w", warn)

--- a/pkg/build/golang/exec.go
+++ b/pkg/build/golang/exec.go
@@ -3,7 +3,6 @@ package golang
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/ipfs/testground/pkg/api"
-	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
 
 	"github.com/hashicorp/go-getter"
 )
@@ -33,7 +32,7 @@ type ExecGoBuilderConfig struct {
 }
 
 // Build builds a testplan written in Go and outputs an executable.
-func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output io.Writer) (*api.BuildOutput, error) {
+func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output *tgwriter.TgWriter) (*api.BuildOutput, error) {
 	cfg, ok := input.BuildConfig.(*ExecGoBuilderConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected configuration type ExecGoBuilderConfig, was: %T", input.BuildConfig)
@@ -132,7 +131,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output
 	cmd.Dir = plandst
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logging.S().Errorf("go build failed: %s", string(out))
+		output.Errorf("go build failed: %s", string(out))
 		return nil, fmt.Errorf("failed to run the build; %w", err)
 	}
 

--- a/pkg/build/golang/exec.go
+++ b/pkg/build/golang/exec.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/ipfs/testground/pkg/api"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 
 	"github.com/hashicorp/go-getter"
 )
@@ -32,7 +32,7 @@ type ExecGoBuilderConfig struct {
 }
 
 // Build builds a testplan written in Go and outputs an executable.
-func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output *tgwriter.TgWriter) (*api.BuildOutput, error) {
+func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, ow *rpc.OutputWriter) (*api.BuildOutput, error) {
 	cfg, ok := input.BuildConfig.(*ExecGoBuilderConfig)
 	if !ok {
 		return nil, fmt.Errorf("expected configuration type ExecGoBuilderConfig, was: %T", input.BuildConfig)
@@ -131,7 +131,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, input *api.BuildInput, output
 	cmd.Dir = plandst
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		output.Errorf("go build failed: %s", string(out))
+		ow.Errorf("go build failed: %s", string(out))
 		return nil, fmt.Errorf("failed to run the build; %w", err)
 	}
 

--- a/pkg/build/golang/selector_test.go
+++ b/pkg/build/golang/selector_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/client"
-
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/build/golang"
 	"github.com/ipfs/testground/pkg/config"
 	"github.com/ipfs/testground/pkg/engine"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,7 +58,7 @@ func TestBuildSelector(t *testing.T) {
 			}
 
 			// this build is using the "foo" and "bar" selectors; it will fail.
-			_, err = engine.DoBuild(context.TODO(), comp, tgwriter.Discard())
+			_, err = engine.DoBuild(context.TODO(), comp, rpc.Discard())
 			assertion(err)
 		}
 

--- a/pkg/build/golang/selector_test.go
+++ b/pkg/build/golang/selector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/testground/pkg/build/golang"
 	"github.com/ipfs/testground/pkg/config"
 	"github.com/ipfs/testground/pkg/engine"
+	"github.com/ipfs/testground/pkg/tgwriter"
 
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +59,7 @@ func TestBuildSelector(t *testing.T) {
 			}
 
 			// this build is using the "foo" and "bar" selectors; it will fail.
-			_, err = engine.DoBuild(context.TODO(), comp, ioutil.Discard)
+			_, err = engine.DoBuild(context.TODO(), comp, tgwriter.Discard())
 			assertion(err)
 		}
 

--- a/pkg/daemon/build.go
+++ b/pkg/daemon/build.go
@@ -18,7 +18,7 @@ func (srv *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r
 		log.Debugw("handle request", "command", "build")
 		defer log.Debugw("request handled", "command", "build")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		var req client.BuildRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/build.go
+++ b/pkg/daemon/build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +18,7 @@ func (srv *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r
 		log.Debugw("handle request", "command", "build")
 		defer log.Debugw("request handled", "command", "build")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		var req client.BuildRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/describe.go
+++ b/pkg/daemon/describe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 var TermExplanation = "a term is any of: <testplan> or <testplan>/<testcase>"
@@ -21,7 +21,7 @@ func (srv *Daemon) describeHandler(engine api.Engine) func(w http.ResponseWriter
 		log.Debugw("handle request", "command", "describe")
 		defer log.Debugw("request handled", "command", "describe")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		var req client.DescribeRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/describe.go
+++ b/pkg/daemon/describe.go
@@ -21,7 +21,7 @@ func (srv *Daemon) describeHandler(engine api.Engine) func(w http.ResponseWriter
 		log.Debugw("handle request", "command", "describe")
 		defer log.Debugw("request handled", "command", "describe")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		var req client.DescribeRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
@@ -59,23 +59,14 @@ func (srv *Daemon) describeHandler(engine api.Engine) func(w http.ResponseWriter
 			return
 		}
 
-		plan.Describe(tgw)
-
-		header := `TESTCASES:
-----------
-----------
-`
-
-		_, err = tgw.Write([]byte(header))
-		if err != nil {
-			tgw.WriteError("header write error", "err", err)
-			return
-		}
+		var sb strings.Builder
+		plan.Describe(&sb)
+		sb.WriteString("TEST CASES:\n----------\n----------\n")
 
 		for _, tc := range cases {
-			tc.Describe(tgw)
+			tc.Describe(&sb)
 		}
 
-		tgw.WriteResult(struct{}{})
+		tgw.WriteResult(sb.String())
 	}
 }

--- a/pkg/daemon/healthcheck.go
+++ b/pkg/daemon/healthcheck.go
@@ -17,7 +17,7 @@ func (srv *Daemon) healthcheckHandler(engine api.Engine) func(w http.ResponseWri
 		log.Debugw("handle request", "command", "healthcheck")
 		defer log.Debugw("request handled", "command", "healthcheck")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		var req client.HealthcheckRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/healthcheck.go
+++ b/pkg/daemon/healthcheck.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) healthcheckHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +17,7 @@ func (srv *Daemon) healthcheckHandler(engine api.Engine) func(w http.ResponseWri
 		log.Debugw("handle request", "command", "healthcheck")
 		defer log.Debugw("request handled", "command", "healthcheck")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		var req client.HealthcheckRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/list.go
+++ b/pkg/daemon/list.go
@@ -15,7 +15,7 @@ func (srv *Daemon) listHandler(engine api.Engine) func(w http.ResponseWriter, r 
 		log.Debugw("handle request", "command", "list")
 		defer log.Debugw("request handled", "command", "list")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		plans := engine.TestCensus().ListPlans()
 		for _, tp := range plans {

--- a/pkg/daemon/list.go
+++ b/pkg/daemon/list.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) listHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -15,7 +15,7 @@ func (srv *Daemon) listHandler(engine api.Engine) func(w http.ResponseWriter, r 
 		log.Debugw("handle request", "command", "list")
 		defer log.Debugw("request handled", "command", "list")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		plans := engine.TestCensus().ListPlans()
 		for _, tp := range plans {

--- a/pkg/daemon/outputs.go
+++ b/pkg/daemon/outputs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) outputsHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -25,7 +25,7 @@ func (srv *Daemon) outputsHandler(engine api.Engine) func(w http.ResponseWriter,
 			return
 		}
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		err = engine.DoCollectOutputs(r.Context(), req.Runner, req.RunID, tgw)
 		if err != nil {

--- a/pkg/daemon/outputs.go
+++ b/pkg/daemon/outputs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 func (srv *Daemon) outputsHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +25,9 @@ func (srv *Daemon) outputsHandler(engine api.Engine) func(w http.ResponseWriter,
 			return
 		}
 
-		err = engine.DoCollectOutputs(r.Context(), req.Runner, req.RunID, w)
+		tgw := tgwriter.New(w, r)
+
+		err = engine.DoCollectOutputs(r.Context(), req.Runner, req.RunID, tgw)
 		if err != nil {
 			log.Errorw("collect outputs error", "err", err.Error())
 			return

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) runHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +18,7 @@ func (srv *Daemon) runHandler(engine api.Engine) func(w http.ResponseWriter, r *
 		log.Debugw("handle request", "command", "run")
 		defer log.Debugw("request handled", "command", "run")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		var req client.RunRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -18,7 +18,7 @@ func (srv *Daemon) runHandler(engine api.Engine) func(w http.ResponseWriter, r *
 		log.Debugw("handle request", "command", "run")
 		defer log.Debugw("request handled", "command", "run")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		var req client.RunRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/terminate.go
+++ b/pkg/daemon/terminate.go
@@ -17,7 +17,7 @@ func (srv *Daemon) terminateHandler(engine api.Engine) func(w http.ResponseWrite
 		log.Debugw("handle request", "command", "terminate")
 		defer log.Debugw("request handled", "command", "terminate")
 
-		tgw := tgwriter.New(w, log)
+		tgw := tgwriter.New(w, r)
 
 		var req client.TerminateRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/daemon/terminate.go
+++ b/pkg/daemon/terminate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/client"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 func (srv *Daemon) terminateHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +17,7 @@ func (srv *Daemon) terminateHandler(engine api.Engine) func(w http.ResponseWrite
 		log.Debugw("handle request", "command", "terminate")
 		defer log.Debugw("request handled", "command", "terminate")
 
-		tgw := tgwriter.New(w, r)
+		tgw := rpc.NewOutputWriter(w, r)
 
 		var req client.TerminateRequest
 		err := json.NewDecoder(r.Body).Decode(&req)

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-
-	"go.uber.org/zap"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 type EnsureContainerOpts struct {
@@ -23,10 +21,10 @@ type EnsureContainerOpts struct {
 	PullImageIfMissing bool
 }
 
-func CheckContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, name string) (container *types.ContainerJSON, err error) {
-	log = log.With("container_name", name)
+func CheckContainer(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client, name string) (container *types.ContainerJSON, err error) {
+	ow = ow.With("container_name", name)
 
-	log.Debug("checking state of container")
+	ow.Debug("checking state of container")
 
 	// Check if a ${name} container exists.
 	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
@@ -39,11 +37,11 @@ func CheckContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cli
 
 	c := containers[0]
 
-	log.Debugw("container found", "container_id", c.ID, "state", c.State)
+	ow.Debugw("container found", "container_id", c.ID, "state", c.State)
 
 	ci, err := cli.ContainerInspect(ctx, c.ID)
 	if err != nil {
-		log.Errorw("inspecting container failed", "container_id", container.ID)
+		ow.Errorw("inspecting container failed", "container_id", c.ID)
 		return nil, err
 	}
 
@@ -52,13 +50,13 @@ func CheckContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cli
 }
 
 // EnsureContainer ensures there's a container started of the specified kind.
-func EnsureContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Client,
+func EnsureContainer(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client,
 	opts *EnsureContainerOpts) (container *types.ContainerJSON, created bool, err error) {
-	log = log.With("container_name", opts.ContainerName)
+	log := ow.With("container_name", opts.ContainerName)
 
 	log.Debug("checking state of container")
 
-	ci, err := CheckContainer(ctx, log, cli, opts.ContainerName)
+	ci, err := CheckContainer(ctx, ow, cli, opts.ContainerName)
 	if err != nil {
 		return nil, false, err
 	}
@@ -76,7 +74,7 @@ func EnsureContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cl
 			return nil, false, err
 		}
 
-		ci, err = CheckContainer(ctx, log, cli, opts.ContainerName)
+		ci, err = CheckContainer(ctx, ow, cli, opts.ContainerName)
 		return ci, false, err
 	}
 
@@ -88,7 +86,7 @@ func EnsureContainer(ctx context.Context, log *zap.SugaredLogger, cli *client.Cl
 			return nil, false, err
 		}
 
-		if err := PipeOutput(out, os.Stdout); err != nil {
+		if err := PipeOutput(out, ow.StdoutWriter()); err != nil {
 			return nil, false, err
 		}
 	} else {

--- a/pkg/docker/network.go
+++ b/pkg/docker/network.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types/filters"
-	"go.uber.org/zap"
+	"github.com/ipfs/testground/pkg/rpc"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
@@ -27,7 +27,7 @@ func NewBridgeNetwork(ctx context.Context, cli *client.Client, name string, inte
 	return res.ID, nil
 }
 
-func CheckBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, name string) ([]types.NetworkResource, error) {
+func CheckBridgeNetwork(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client, name string) ([]types.NetworkResource, error) {
 	opts := types.NetworkListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("name", name),
@@ -37,15 +37,15 @@ func CheckBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *client
 	return cli.NetworkList(ctx, opts)
 }
 
-func EnsureBridgeNetwork(ctx context.Context, log *zap.SugaredLogger, cli *client.Client, name string, internal bool, config ...network.IPAMConfig) (id string, err error) {
-	networks, err := CheckBridgeNetwork(ctx, log, cli, name)
+func EnsureBridgeNetwork(ctx context.Context, ow *rpc.OutputWriter, cli *client.Client, name string, internal bool, config ...network.IPAMConfig) (id string, err error) {
+	networks, err := CheckBridgeNetwork(ctx, ow, cli, name)
 	if err != nil {
 		return "", err
 	}
 
 	if len(networks) > 0 {
 		network := networks[0]
-		log.Debugw("network found", "name", name, "id", network.ID)
+		ow.Debugw("network found", "name", name, "id", network.ID)
 		return network.ID, nil
 	}
 

--- a/pkg/rpc/chunk.go
+++ b/pkg/rpc/chunk.go
@@ -1,0 +1,23 @@
+package rpc
+
+// ChunkType defines the type of a chunk.
+type ChunkType rune
+
+const (
+	ChunkTypeProgress ChunkType = 'p'
+	ChunkTypeResult   ChunkType = 'r'
+	ChunkTypeError    ChunkType = 'e'
+)
+
+// Chunk is a response chunk sent from the Testground daemon to the Testground
+// client. For a given request, clients should expect between 0 to `n`
+// `progress` chunks, and exactly 1 `result` or `error` chunk before EOF.
+type Chunk struct {
+	Type    ChunkType   `json:"t"` // progress or result or error
+	Payload interface{} `json:"p,omitempty"`
+	Error   *Error      `json:"e,omitempty"`
+}
+
+type Error struct {
+	Msg string `json:"m"`
+}

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/aws"
 	"github.com/ipfs/testground/pkg/conv"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 	"github.com/ipfs/testground/sdk/runtime"
 	"golang.org/x/sync/errgroup"
 
@@ -68,7 +68,7 @@ type ClusterSwarmRunner struct{}
 
 // TODO runner option to keep containers alive instead of deleting them after
 // the test has run.
-func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *tgwriter.TgWriter) (*api.RunOutput, error) {
+func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc.OutputWriter) (*api.RunOutput, error) {
 	var (
 		seq = input.Seq
 		log = ow.With("runner", "cluster:swarm", "run_id", input.RunID)
@@ -379,7 +379,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *tgw
 	return &api.RunOutput{RunID: input.RunID}, nil
 }
 
-func (*ClusterSwarmRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w *tgwriter.TgWriter) error {
+func (*ClusterSwarmRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, ow *rpc.OutputWriter) error {
 	return errors.New("unimplemented")
 }
 

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/aws"
 	"github.com/ipfs/testground/pkg/conv"
-	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
 	"github.com/ipfs/testground/sdk/runtime"
 	"golang.org/x/sync/errgroup"
 
@@ -68,10 +68,10 @@ type ClusterSwarmRunner struct{}
 
 // TODO runner option to keep containers alive instead of deleting them after
 // the test has run.
-func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *tgwriter.TgWriter) (*api.RunOutput, error) {
 	var (
 		seq = input.Seq
-		log = logging.S().With("runner", "cluster:swarm", "run_id", input.RunID)
+		log = ow.With("runner", "cluster:swarm", "run_id", input.RunID)
 		cfg = *input.RunnerConfig.(*ClusterSwarmRunnerConfig)
 	)
 
@@ -189,7 +189,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 		}
 	}()
 
-	logging.S().Infof("fetching an authorization token from AWS ECR")
+	ow.Infof("fetching an authorization token from AWS ECR")
 
 	// Get an authorization token from AWS ECR.
 	auth, err := aws.ECR.GetAuthToken(input.EnvConfig.AWS)
@@ -197,7 +197,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 		return nil, err
 	}
 
-	logging.S().Infof("fetched an authorization token from AWS ECR")
+	ow.Infof("fetched an authorization token from AWS ECR")
 
 	services := make(map[string]int, len(input.Groups))
 	for _, g := range input.Groups {
@@ -267,7 +267,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 			EncodedRegistryAuth: aws.ECR.EncodeAuthToken(auth),
 		}
 
-		logging.S().Infow("creating the service on docker swarm", "parent", parent, "group", g.ID, "image", g.ArtifactPath, "replicas", g.Instances)
+		ow.Infow("creating the service on docker swarm", "parent", parent, "group", g.ID, "image", g.ArtifactPath, "replicas", g.Instances)
 
 		// Now create the docker swarm service.
 		serviceResp, err := cli.ServiceCreate(ctx, serviceSpec, scopts)
@@ -275,7 +275,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 			return nil, err
 		}
 
-		logging.S().Infow("service created successfully", "id", serviceResp.ID)
+		ow.Infow("service created successfully", "id", serviceResp.ID)
 
 		services[serviceResp.ID] = g.Instances
 	}
@@ -339,7 +339,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 							finished++
 						}
 					}
-					logging.S().Infow("task status", "service", service, "status", status)
+					ow.Infow("task status", "service", service, "status", status)
 					if finished == count {
 						break
 					}
@@ -364,12 +364,12 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 		defer cancel()
 
 		for service := range services {
-			logging.S().Infow("removing service", "service", service)
+			ow.Infow("removing service", "service", service)
 
 			if err := cli.ServiceRemove(ctx, service); err == nil {
-				logging.S().Infow("service removed", "service", service)
+				ow.Infow("service removed", "service", service)
 			} else {
-				logging.S().Errorf("removing the service failed: %w", err)
+				ow.Errorf("removing the service failed: %w", err)
 			}
 		}
 	} else {
@@ -379,7 +379,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow io.W
 	return &api.RunOutput{RunID: input.RunID}, nil
 }
 
-func (*ClusterSwarmRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w io.Writer) error {
+func (*ClusterSwarmRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w *tgwriter.TgWriter) error {
 	return errors.New("unimplemented")
 }
 

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ipfs/testground/pkg/api"
+	"github.com/ipfs/testground/pkg/tgwriter"
 )
 
 // Use consistent IP address ranges for both the data and the control subnet.
@@ -36,7 +37,7 @@ func nextDataNetwork(lenNetworks int) (*net.IPNet, string, error) {
 	return subnet, gw, err
 }
 
-func zipRunOutputs(ctx context.Context, basedir string, input *api.CollectionInput, w io.Writer) error {
+func zipRunOutputs(ctx context.Context, basedir string, input *api.CollectionInput, w *tgwriter.TgWriter) error {
 	pattern := filepath.Join(basedir, "*", input.RunID)
 
 	matches, err := filepath.Glob(pattern)

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/ipfs/testground/pkg/api"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 )
 
 // Use consistent IP address ranges for both the data and the control subnet.
@@ -37,7 +37,7 @@ func nextDataNetwork(lenNetworks int) (*net.IPNet, string, error) {
 	return subnet, gw, err
 }
 
-func zipRunOutputs(ctx context.Context, basedir string, input *api.CollectionInput, w *tgwriter.TgWriter) error {
+func zipRunOutputs(ctx context.Context, basedir string, input *api.CollectionInput, ow *rpc.OutputWriter) error {
 	pattern := filepath.Join(basedir, "*", input.RunID)
 
 	matches, err := filepath.Glob(pattern)
@@ -57,7 +57,7 @@ func zipRunOutputs(ctx context.Context, basedir string, input *api.CollectionInp
 		return fmt.Errorf("internal error: not a directory when accessing run outputs")
 	}
 
-	wz := zip.NewWriter(w)
+	wz := zip.NewWriter(ow)
 	defer wz.Close()
 	defer wz.Flush()
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/conv"
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
@@ -78,7 +78,7 @@ func commandStarter(ctx context.Context, cmd string, args ...string) func() erro
 	}
 }
 
-func (r *LocalExecutableRunner) Healthcheck(fix bool, engine api.Engine, writer *tgwriter.TgWriter) (*api.HealthcheckReport, error) {
+func (r *LocalExecutableRunner) Healthcheck(fix bool, engine api.Engine, ow *rpc.OutputWriter) (*api.HealthcheckReport, error) {
 	r.lk.Lock()
 	defer r.lk.Unlock()
 
@@ -183,7 +183,7 @@ func (r *LocalExecutableRunner) Close() error {
 	return nil
 }
 
-func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow *tgwriter.TgWriter) (*api.RunOutput, error) {
+func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc.OutputWriter) (*api.RunOutput, error) {
 	r.lk.RLock()
 	defer r.lk.RUnlock()
 
@@ -268,9 +268,9 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 	return &api.RunOutput{RunID: input.RunID}, nil
 }
 
-func (*LocalExecutableRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w *tgwriter.TgWriter) error {
+func (*LocalExecutableRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, ow *rpc.OutputWriter) error {
 	basedir := filepath.Join(input.EnvConfig.WorkDir(), "local_exec", "outputs")
-	return zipRunOutputs(ctx, basedir, input, w)
+	return zipRunOutputs(ctx, basedir, input, ow)
 }
 
 func (*LocalExecutableRunner) ID() string {

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -3,13 +3,13 @@ package runner
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
-	"io"
+	"golang.org/x/sync/errgroup"
+
 	"net"
 	"os/exec"
 	"reflect"
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/testground/pkg/api"
 	"github.com/ipfs/testground/pkg/conv"
 	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
@@ -77,7 +78,7 @@ func commandStarter(ctx context.Context, cmd string, args ...string) func() erro
 	}
 }
 
-func (r *LocalExecutableRunner) Healthcheck(fix bool, engine api.Engine, writer io.Writer) (*api.HealthcheckReport, error) {
+func (r *LocalExecutableRunner) Healthcheck(fix bool, engine api.Engine, writer *tgwriter.TgWriter) (*api.HealthcheckReport, error) {
 	r.lk.Lock()
 	defer r.lk.Unlock()
 
@@ -182,7 +183,7 @@ func (r *LocalExecutableRunner) Close() error {
 	return nil
 }
 
-func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow io.Writer) (*api.RunOutput, error) {
+func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow *tgwriter.TgWriter) (*api.RunOutput, error) {
 	r.lk.RLock()
 	defer r.lk.RUnlock()
 
@@ -208,7 +209,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 	}
 
 	// Spawn as many instances as the input parameters require.
-	pretty := NewPrettyPrinter()
+	pretty := NewPrettyPrinter(ow)
 	commands := make([]*exec.Cmd, 0, input.TotalInstances)
 	defer func() {
 		for _, cmd := range commands {
@@ -242,7 +243,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 
 			env := conv.ToOptionsSlice(runenv.ToEnvVars())
 
-			logging.S().Infow("starting test case instance", "plan", name, "group", g.ID, "number", i, "total", total)
+			ow.Infow("starting test case instance", "plan", name, "group", g.ID, "number", i, "total", total)
 
 			cmd := exec.CommandContext(ctx, g.ArtifactPath)
 			stdout, _ := cmd.StdoutPipe()
@@ -267,7 +268,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 	return &api.RunOutput{RunID: input.RunID}, nil
 }
 
-func (*LocalExecutableRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w io.Writer) error {
+func (*LocalExecutableRunner) CollectOutputs(ctx context.Context, input *api.CollectionInput, w *tgwriter.TgWriter) error {
 	basedir := filepath.Join(input.EnvConfig.WorkDir(), "local_exec", "outputs")
 	return zipRunOutputs(ctx, basedir, input, w)
 }

--- a/pkg/runner/pretty.go
+++ b/pkg/runner/pretty.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ipfs/testground/pkg/logging"
+	"github.com/ipfs/testground/pkg/tgwriter"
 	"github.com/ipfs/testground/sdk/runtime"
 
 	"github.com/logrusorgru/aurora"
@@ -39,6 +40,7 @@ func (et eventType) String() string {
 type PrettyPrinter struct {
 	aurora  aurora.Aurora
 	classes [10]aurora.Value
+	tgw     *tgwriter.TgWriter
 
 	// guarded by atomic.
 	failed uint32
@@ -49,7 +51,7 @@ type PrettyPrinter struct {
 }
 
 // NewPrettyPrinter constructs a new console logger.
-func NewPrettyPrinter() *PrettyPrinter {
+func NewPrettyPrinter(tgw *tgwriter.TgWriter) *PrettyPrinter {
 	au := aurora.NewAurora(logging.IsTerminal())
 	return &PrettyPrinter{
 		aurora: au,
@@ -66,6 +68,7 @@ func NewPrettyPrinter() *PrettyPrinter {
 			aurora.BgBrightRed("INTERNAL_ERR").White(),
 		},
 		start: time.Now(),
+		tgw:   tgw,
 	}
 }
 
@@ -216,7 +219,7 @@ func (c *PrettyPrinter) print(idx uint32, id string, now time.Time, evtType even
 		elapsed = 0
 	}
 
-	fmt.Printf("%9.4fs %10s %s %s\n",
+	c.tgw.Infof("%5.4fs %10s %s %s",
 		float64(elapsed)/float64(time.Second),
 		class,
 		c.aurora.Index(uint8(idx%15)+1, "<< "+id+" >>"),

--- a/pkg/runner/pretty.go
+++ b/pkg/runner/pretty.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/ipfs/testground/pkg/logging"
-	"github.com/ipfs/testground/pkg/tgwriter"
+	"github.com/ipfs/testground/pkg/rpc"
 	"github.com/ipfs/testground/sdk/runtime"
 
 	"github.com/logrusorgru/aurora"
@@ -40,7 +40,7 @@ func (et eventType) String() string {
 type PrettyPrinter struct {
 	aurora  aurora.Aurora
 	classes [10]aurora.Value
-	tgw     *tgwriter.TgWriter
+	ow      *rpc.OutputWriter
 
 	// guarded by atomic.
 	failed uint32
@@ -51,7 +51,7 @@ type PrettyPrinter struct {
 }
 
 // NewPrettyPrinter constructs a new console logger.
-func NewPrettyPrinter(tgw *tgwriter.TgWriter) *PrettyPrinter {
+func NewPrettyPrinter(ow *rpc.OutputWriter) *PrettyPrinter {
 	au := aurora.NewAurora(logging.IsTerminal())
 	return &PrettyPrinter{
 		aurora: au,
@@ -68,7 +68,7 @@ func NewPrettyPrinter(tgw *tgwriter.TgWriter) *PrettyPrinter {
 			aurora.BgBrightRed("INTERNAL_ERR").White(),
 		},
 		start: time.Now(),
-		tgw:   tgw,
+		ow:    ow,
 	}
 }
 
@@ -219,7 +219,7 @@ func (c *PrettyPrinter) print(idx uint32, id string, now time.Time, evtType even
 		elapsed = 0
 	}
 
-	c.tgw.Infof("%5.4fs %10s %s %s",
+	c.ow.Infof("%5.4fs %10s %s %s",
 		float64(elapsed)/float64(time.Second),
 		class,
 		c.aurora.Index(uint8(idx%15)+1, "<< "+id+" >>"),

--- a/pkg/tgwriter/tgwriter.go
+++ b/pkg/tgwriter/tgwriter.go
@@ -4,35 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
 
-	"github.com/docker/docker/pkg/ioutils"
+	"github.com/ipfs/testground/pkg/logging"
 
+	"github.com/docker/docker/pkg/ioutils"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-func New(w http.ResponseWriter, log *zap.SugaredLogger) *TgWriter {
-	w.Header().Set("Content-Type", "application/json")
-
-	return &TgWriter{
-		output: ioutils.NewWriteFlusher(w),
-		log:    log,
-	}
-}
-
-type TgWriter struct {
-	sync.Mutex
-
-	io.Writer
-	output io.Writer
-	log    *zap.SugaredLogger
-}
-
-// Msg defines a protocol message struct sent from the Testground daemon to the Testground client.
-// For a given request, clients should expect between 1 and `n` `progress` messages, and
-// exactly 1 `result` message.
+// Msg defines a protocol message struct sent from the Testground daemon to the
+// Testground client. For a given request, clients should expect between 0 to
+// `n` `progress` messages, and exactly 1 `result` message.
 type Msg struct {
 	Type    string      `json:"type"` // progress or result or error
 	Payload interface{} `json:"payload,omitempty"`
@@ -43,50 +29,93 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-func (tgw *TgWriter) Write(p []byte) (n int, err error) {
+func New(w http.ResponseWriter, r *http.Request) *TgWriter {
+	w.Header().Set("Content-Type", "application/json")
+
+	httpWriter := ioutils.NewWriteFlusher(w)
+
+	// progressWriter will emit log output as progress messages.
+	progressWriter := &progressWriter{out: httpWriter}
+	writeSyncer := zapcore.Lock(zapcore.AddSync(progressWriter))
+
+	// this logger has two sinks: stdout and the writeSyncer, wired to the HTTP
+	// response.
+	logger := logging.NewLogger(writeSyncer).With(zap.String("req_id", r.Header.Get("X-Request-ID")))
+
+	tgw := &TgWriter{
+		SugaredLogger:  logger.Sugar(),
+		out:            httpWriter,
+		progressWriter: progressWriter,
+	}
+
+	// we need to wire this back for the lock.
+	progressWriter.tgw = tgw
+	return tgw
+}
+
+func Discard() *TgWriter {
+	pw := &progressWriter{out: ioutil.Discard}
+	tgw := &TgWriter{
+		SugaredLogger:  zap.NewNop().Sugar(),
+		out:            ioutil.Discard,
+		progressWriter: pw,
+	}
+	tgw.progressWriter = pw
+	return tgw
+}
+
+type progressWriter struct {
+	tgw *TgWriter
+	out io.Writer
+}
+
+var _ io.Writer = (*progressWriter)(nil)
+
+// Write on the logWriter wraps the incoming write into a progress message.
+func (w *progressWriter) Write(p []byte) (n int, err error) {
 	if p == nil {
 		return 0, nil
 	}
 
-	pld := Msg{
-		Type:    "progress",
-		Payload: p,
-	}
-
-	json, err := json.Marshal(pld)
+	msg := Msg{Type: "progress", Payload: p}
+	json, err := json.Marshal(msg)
 	if err != nil {
 		return 0, err
 	}
 
-	tgw.Lock()
-	defer tgw.Unlock()
+	w.tgw.Lock()
+	defer w.tgw.Unlock()
 
-	return tgw.output.Write(json)
+	return w.out.Write(json)
+}
+
+type TgWriter struct {
+	sync.Mutex
+	*zap.SugaredLogger
+	*progressWriter
+
+	out io.Writer
 }
 
 func (tgw *TgWriter) WriteResult(res interface{}) {
-	pld := Msg{
-		Type:    "result",
-		Payload: res,
-	}
-
-	json, err := json.Marshal(pld)
+	msg := Msg{Type: "result", Payload: res}
+	json, err := json.Marshal(msg)
 	if err != nil {
-		tgw.log.Errorw("could not write result", "err", err)
+		logging.S().Errorw("could not write result", "err", err)
 		return
 	}
 
 	tgw.Lock()
 	defer tgw.Unlock()
 
-	_, err = tgw.output.Write(json)
+	_, err = tgw.out.Write(json)
 	if err != nil {
-		tgw.log.Errorw("could not write result", "err", err)
+		logging.S().Errorw("could not write result", "err", err)
 	}
 }
 
 func (tgw *TgWriter) WriteError(message string, keysAndValues ...interface{}) {
-	tgw.log.Warnw(message, keysAndValues...)
+	tgw.Warnw(message, keysAndValues...)
 
 	if len(keysAndValues) > 0 {
 		b := &strings.Builder{}
@@ -97,30 +126,24 @@ func (tgw *TgWriter) WriteError(message string, keysAndValues ...interface{}) {
 		message = message + "; " + kvs[:len(kvs)-1]
 	}
 
-	pld := Msg{
-		Type: "error",
-		Error: &Error{
-			Message: message,
-		},
-	}
-
+	pld := Msg{Type: "error", Error: &Error{message}}
 	json, err := json.Marshal(pld)
 	if err != nil {
-		tgw.log.Errorw("could not write error response", "err", err)
+		logging.S().Errorw("could not write error response", "err", err)
 		return
 	}
 
 	tgw.Lock()
 	defer tgw.Unlock()
 
-	_, err = tgw.output.Write(json)
+	_, err = tgw.out.Write(json)
 	if err != nil {
-		tgw.log.Errorw("could not write error response", "err", err)
+		logging.S().Errorw("could not write error response", "err", err)
 	}
 }
 
 func (tgw *TgWriter) Flush() {
-	if f, ok := tgw.output.(http.Flusher); ok {
+	if f, ok := tgw.out.(http.Flusher); ok {
 		f.Flush()
 	}
 }


### PR DESCRIPTION
Fixes #306.

---

* This refactors the `TgWriter` to create and hold a zap.Logger that outputs to two `WriteSyncer`s: `stdout` and the HTTP response.

* Log statements written on the HTTP response make it over as `progress` messages.

* All operations on the daemon side have been refactored to log via the `TgWriter`, which will create the log event once and tee it into two writers. I discarded using [`zapcore.NewTee()`](https://godoc.org/go.uber.org/zap/zapcore#NewTee), because that would process the log event _twice_, and incur in more overhead than necessary.

## TODO

- [x] Rename `TgWriter` to something nicer.
- [x] Move it to another package: `rpc`. ~, maybe `tgio` or an existing package.~
- [x] Name the `TgWriter` variables consistently across the board.