### PR TITLE
CI fails for pointer error

### DIFF
--- a/pkg/rpc/writer.go
+++ b/pkg/rpc/writer.go
@@ -59,6 +59,7 @@ func Discard() *OutputWriter {
 		progressWriter: pw,
 	}
 	ow.progressWriter = pw
+	pw.ow = ow
 	return ow
 }
 


### PR DESCRIPTION
quickfix. 

CI was failing for a pointer error, and it was a problem with the Discard output writer.