### PR TITLE
set efs-provisioner on flannel network

### DIFF
--- a/infra/k8s/efs/manifest.yaml.spec
+++ b/infra/k8s/efs/manifest.yaml.spec
@@ -8,6 +8,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: efs-provisioner
+  annotations:
+    cni: "flannel"
 spec:
   replicas: 1
   selector:
@@ -17,6 +19,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        cni: "flannel"
       labels:
         app: efs-provisioner
     spec:


### PR DESCRIPTION
An attempt to fix https://github.com/ipfs/testground/issues/732

---

It doesn't however fix it, but the `efs-provisioner` container ends up on the `flannel` network:

```
efs-provisioner-65c9486f47-q6khv                       1/1     Running   0          6m55s   100.96.9.3      ip-172-20-36-207.eu-central-1.compute.internal   <none>           <none>
```