### PR TITLE
cnigenie: add flannel as default network

### DIFF
--- a/infra/k8s/kops-weave/genie-plugin.yaml
+++ b/infra/k8s/kops-weave/genie-plugin.yaml
@@ -92,6 +92,7 @@ data:
         "log_level": "info",
         "datastore_type": "kubernetes",
         "hostname": "__KUBERNETES_NODE_NAME__",
+        "default_plugin": "flannel",
         "policy": {
             "type": "k8s",
             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"


### PR DESCRIPTION
Another attempt to fix #732 - I am not sure at the time of the creation of the pod, to which network we are attached so that DNS resolution fails. I wouldn't be surprised if this is Weave.

---

In any case we want `flannel` to be the default network so that we don't add `podAnnotations` to every single resource we install on Kubernetes.

---

What confused me about the default network under CNI-Genie is that on Kubernetes, the first file alphanumerically to appear under `/etc/cni/net.d/` is picked up by Kubernetes as the default CNI plugin. I was somehow under the impression that then CNI-Genie would pick up the first alphanumeric plugin (which would be flannel), but this is not the case, and obviously the meta CNI plugin can pick whichever it wants.
