### PR TITLE
collect cmd: fix when run as --collect

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -55,12 +55,7 @@ func collectCommand(c *cli.Context) error {
 		return err
 	}
 
-	err = collect(ctx, api, runner, id, output)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return collect(ctx, api, runner, id, output)
 }
 
 func collect(ctx context.Context, cl *client.Client, runner string, runid string, outputFile string) error {

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -94,7 +94,8 @@ func collect(ctx context.Context, cl *client.Client, runner string, runid string
 
 	if !cr.Exists {
 		logging.S().Errorw("no such testplan run", "run_id", runid, "runner", runner)
-		return nil
+
+		return os.Remove(outputFile)
 	}
 
 	logging.S().Infof("created file: %s", outputFile)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -191,7 +191,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 	logging.S().Infof("finished run with ID: %s", rout.RunID)
 
 	// if the `collect` flag is not set, we are done, just return
-	collectBool := c.Bool("collect")
+	collectOpt := c.Bool("collect")
 	if !collectBool {
 		return nil
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -192,7 +192,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 
 	// if the `collect` flag is not set, we are done, just return
 	collectOpt := c.Bool("collect")
-	if !collectBool {
+	if !collectOpt {
 		return nil
 	}
 
@@ -201,10 +201,5 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 		collectFile = fmt.Sprintf("%s.tgz", rout.RunID)
 	}
 
-	err = collect(ctx, cl, comp.Global.Runner, rout.RunID, collectFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return collect(ctx, cl, comp.Global.Runner, rout.RunID, collectFile)
 }


### PR DESCRIPTION
`collect` is still broken when called from `testground run ... --collect`.