### PR TITLE
speed up install.sh

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -114,12 +114,11 @@ kubectl apply -f ./efs/rbac.yaml \
               -f $EFS_MANIFEST_SPEC
 
 # monitoring and redis.
-echo "installing helm infrastructure"
+echo "Installing Testground infrastructure - prometheus, pushgateway, redis, dashboards"
 pushd testground-infra
 helm dep build
-helm install --wait --timeout 2m testground-infra .
+helm install testground-infra .
 popd
-sleep 10
 
 echo "Install Weave, CNI-Genie, s3bucket DaemonSet, Sidecar Daemonset..."
 echo


### PR DESCRIPTION
Considering https://github.com/ipfs/testground/pull/768 we no longer need the `helm wait`.

We are confident that the default network is flannel, so no need to wait for resources to come up in order to continue with next steps.

Redis is required for some of the next DaemonSets, but they are implemented with `initContainers` that wait for it, so we are good there.