### PR TITLE
sync/sdk: make Barrier lenient by not failing if value > target.

### DIFF
--- a/sdk/sync/watch.go
+++ b/sdk/sync/watch.go
@@ -187,11 +187,11 @@ func (w *Watcher) Barrier(ctx context.Context, state State, required int64) <-ch
 				return
 			}
 		}
+
 		if last > required {
-			resCh <- fmt.Errorf("when waiting on %s; too many elements, required %d, got %d", state, required, last)
-		} else {
-			resCh <- nil
+			log.Debugf("barrier on state %s: exceeded target count; required: %d, got: %d")
 		}
+		resCh <- nil
 	}()
 
 	return resCh


### PR DESCRIPTION
This allows users to build more synchronisation primitives besides CountDownLatches/WaitGroups on top of Barriers, like semaphores.

cc @aschmahmann 