### PR TITLE
ulimits kubernetes using kops

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -12,6 +12,9 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: ${KOPS_STATE_STORE}/${NAME}
+  docker:
+    defaultUlimit:
+    - "nofile=1048576:1048576"
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -14,7 +14,7 @@ spec:
   configBase: ${KOPS_STATE_STORE}/${NAME}
   docker:
     defaultUlimit:
-    - "nofile=1048576:1048576"
+    - "nofile=2097152:2097152"
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -14,7 +14,7 @@ spec:
   configBase: ${KOPS_STATE_STORE}/${NAME}
   docker:
     defaultUlimit:
-    - "nofile=2097152:2097152"
+    - "nofile=${ULIMIT_NOFILE}"
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -26,7 +26,7 @@ echo
 # Set default options (can be over-ridden by setting environment vars)
 if [ -z "$ULIMIT_NOFILE" ]
 then
-	export ULIMIT="1048576:1048576"
+	export ULIMIT_NOFILE="1048576:1048576"
 fi
 
 CLUSTER_SPEC=$(mktemp)

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -23,6 +23,12 @@ echo "Public key: $PUBKEY"
 echo "Worker nodes: $WORKER_NODES"
 echo
 
+# Set default options (can be over-ridden by setting environment vars)
+if [ -z "$ULIMIT_NOFILE" ]
+then
+	export ULIMIT="1048576:1048576"
+fi
+
 CLUSTER_SPEC=$(mktemp)
 envsubst <$CLUSTER_SPEC_TEMPLATE >$CLUSTER_SPEC
 cat $CLUSTER_SPEC


### PR DESCRIPTION
Kubernetes component of https://github.com/ipfs/testground/issues/781

This took me longer than I had hoped to figure out how to do this, and this is an undocumented kops feature, so I want to give an explanation.

All of the yaml stanzas are serialized into structs, the docker configuration struct is here: https://godoc.org/k8s.io/kops/pkg/apis/kops#DockerConfig

As you DefaultUlimit takes a slice/yaml-list of strings which are formatted with the same function as other docker ulimit strings. This is familiar.: https://github.com/docker/go-units/blob/master/ulimit.go#L66

Pretty simple!

To verify that this is working, log into one of the kops hosts, and have a look at any of the docker containers and see the result:

```
# docker inspect bf24b493fb8b | grep -A5 Ulimit
            "Ulimits": [
                {
                    "Name": "nofile",
                    "Hard": 1048576,
                    "Soft": 1048576
                }
```
