### PR TITLE
disable transparent hugepages earlier (kubernetes)

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -25,6 +25,14 @@ spec:
       name: a
     memoryRequest: 100Mi
     name: events
+  hooks:
+    - name: disable-transparent-hugepages.service
+      before:
+      - docker.service
+      - kubelet.service
+      manifest: |
+        Type=oneshot
+        ExecStart=/bin/sh -c "echo never >/sys/kernel/mm/transparent_hugepage/enabled"
   iam:
     allowContainerRegistry: true
     legacy: false

--- a/infra/k8s/kops-weave/dummy.yml
+++ b/infra/k8s/kops-weave/dummy.yml
@@ -20,13 +20,6 @@ spec:
       - name: host-sys
         hostPath:
           path: /sys
-      initContainers:
-      - name: disable-thp
-        image: busybox
-        volumeMounts:
-          - name: host-sys
-            mountPath: /host-sys
-        command: ["sh", "-c", "echo never >/host-sys/kernel/mm/transparent_hugepage/enabled"]
       containers:
       - name: dummy
         command: ["/bin/sleep", "3650d"]


### PR DESCRIPTION
Fix: https://github.com/ipfs/testground/issues/767

disable transparent-hugepages earlier.

This kops hook creates a systemd unit file which looks like this:

```
# cat /lib/systemd/system/disable-transparent-hugepages.service 
[Unit]
Description=Kops Hook disable-transparent-hugepages.service
Before=docker.service
Before=kubelet.service

[Service]
Type=oneshot
ExecStart=/bin/sh -c "echo never >/sys/kernel/mm/transparent_hugepage/enabled"

```

We can see that it works:
```
# cat /sys/kernel/mm/transparent_hugepage/enabled 
always madvise [never]

```