### PR TITLE
restart containers

### DIFF
--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -854,6 +854,9 @@ func ensureSidecarContainer(ctx context.Context, cli *client.Client, workDir str
 					{Name: "nofile", Hard: InfraMaxFilesUlimit, Soft: InfraMaxFilesUlimit},
 				},
 			},
+			RestartPolicy: container.RestartPolicy{
+				Name: "unless-stopped",
+			},
 		},
 		PullImageIfMissing: false, // Don't pull from Docker Hub
 	})

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -803,6 +803,9 @@ func ensureInfraContainer(ctx context.Context, cli *client.Client, ow *rpc.Outpu
 					{Name: "nofile", Hard: InfraMaxFilesUlimit, Soft: InfraMaxFilesUlimit},
 				},
 			},
+			RestartPolicy: container.RestartPolicy{
+				Name: "unless-stopped",
+			},
 		},
 		PullImageIfMissing: pull,
 	})


### PR DESCRIPTION
Maybe fix: https://github.com/ipfs/testground/issues/691

If https://github.com/ipfs/testground/pull/734 is merged, then this PR is irrelevant and should be canceled. ensureInfraContainer is removed in that PR.


Adds a restart policy, so in case of a crash the container will restart. I'll implement this for the new API separately, please comment if you have any concerns about the restart policy as a general practice.

