### PR TITLE
setting sysctl on the k8s hosts

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -76,6 +76,24 @@ metadata:
     kops.k8s.io/cluster: ${NAME}
   name: master-${ZONE}
 spec:
+  additionalUserData:
+  - name: myscript.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      cat <<EOT >> /etc/sysctl.d/999-testground.conf
+      net.core.somaxconn = 100000
+      net.ipv4.tcp_max_syn_backlog = 100000
+      net.core.netdev_max_backlog = 100000
+      net.ipv4.ip_local_port_range = 1024 65535
+      net.ipv4.tcp_tw_recycle = 1
+      net.ipv4.tcp_tw_reuse = 1
+      net.core.rmem_max = 134217728
+      net.core.wmem_max = 134217728
+      net.ipv4.tcp_rmem = 4096 12582912 67108864
+      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      EOT
+  image: 595879546273/CoreOS-stable-1576.5.0-hvm
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: 1
@@ -96,6 +114,23 @@ metadata:
     kops.k8s.io/cluster: ${NAME}
   name: nodes
 spec:
+  additionalUserData:
+  - name: myscript.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      cat <<EOT >> /etc/sysctl.d/999-testground.conf
+      net.core.somaxconn = 100000
+      net.ipv4.tcp_max_syn_backlog = 100000
+      net.core.netdev_max_backlog = 100000
+      net.ipv4.ip_local_port_range = 1024 65535
+      net.ipv4.tcp_tw_recycle = 1
+      net.ipv4.tcp_tw_reuse = 1
+      net.core.rmem_max = 134217728
+      net.core.wmem_max = 134217728
+      net.ipv4.tcp_rmem = 4096 12582912 67108864
+      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: ${WORKER_NODES}

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -40,8 +40,19 @@ spec:
     anonymousAuth: false
     maxPods: 200
     allowedUnsafeSysctls:
-      - net.core.somaxconn
       - net.netfilter.nf_conntrack_max
+      - net.core.somaxconn
+      - net.core.netdev_max_backlog
+      - net.core.rmem_max
+      - net.core.wmem_max
+      - net.ipv4.ip_local_port_range
+      - net.ipv4.tcp_max_syn_backlog
+      - net.ipv4.tcp_tw_recycle
+      - net.ipv4.tcp_tw_reuse
+      - net.ipv4.tcp_rmem
+      - net.ipv4.tcp_wmem
+      - net.ipv4.tcp_max_orphans
+      - net.ipv4.tcp_abort_on_overflow
     streamingConnectionIdleTimeout: 60m
   kubernetesApiAccess:
   - 0.0.0.0/0
@@ -93,7 +104,6 @@ spec:
       net.ipv4.tcp_rmem = 4096 12582912 67108864
       net.ipv4.tcp_wmem = 4096 12582912 67108864
       EOT
-  image: 595879546273/CoreOS-stable-1576.5.0-hvm
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: 1


### PR DESCRIPTION
Choice of filename is because the AMI already has other configs in the `sysctl.d` directory:

```
root@ip-172-20-58-91:/etc/sysctl.d# ls -la
total 24
drwxr-xr-x  2 root root 4096 Apr  3 14:23 .
drwxr-xr-x 84 root root 4096 Apr  3 14:24 ..
-rw-r--r--  1 root root  468 Jan 17 11:42 01_ec2.conf
-rw-r--r--  1 root root 1519 Apr  3 14:23 99-k8s-general.conf
lrwxrwxrwx  1 root root   14 Jul 21  2019 99-sysctl.conf -> ../sysctl.conf
-rw-r--r--  1 root root  345 Apr  3 14:23 999-testground.conf
-rw-r--r--  1 root root  639 May 17  2018 README.sysctl
```