### PR TITLE
increase conntrack from 100k to 1mln

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -94,6 +94,7 @@ spec:
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 100000
+      net.netfilter.nf_conntrack_max = 1000000
       net.ipv4.tcp_max_syn_backlog = 100000
       net.core.netdev_max_backlog = 100000
       net.ipv4.ip_local_port_range = 1024 65535
@@ -131,6 +132,7 @@ spec:
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 100000
+      net.netfilter.nf_conntrack_max = 1000000
       net.ipv4.tcp_max_syn_backlog = 100000
       net.core.netdev_max_backlog = 100000
       net.ipv4.ip_local_port_range = 1024 65535

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -130,7 +130,7 @@ redis:
       - name: net.core.somaxconn
         value: "100000"
       - name: net.netfilter.nf_conntrack_max
-        value: "100000"
+        value: "1000000"
   master:
     extraFlags:
       - "--maxclients 100000"


### PR DESCRIPTION
https://www.projectcalico.org/when-linux-conntrack-is-no-longer-your-friend/

https://morganwu277.github.io/2018/05/26/Solve-production-issue-of-nf-conntrack-table-full-dropping-packet/

---

```
Recommended size: CONNTRACK_MAX = RAMSIZE (in bytes) / 16384 / (ARCH / 32)
```

For c5.2xlarge 1mln is probably too much, but we should be fine with at least 300k.