### PR TITLE
update linux networking stack configuration.

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -49,6 +49,7 @@ spec:
       - net.ipv4.tcp_max_syn_backlog
       - net.ipv4.tcp_tw_recycle
       - net.ipv4.tcp_tw_reuse
+      - net.ipv4.tcp_mem
       - net.ipv4.tcp_rmem
       - net.ipv4.tcp_wmem
       - net.ipv4.tcp_max_orphans
@@ -93,17 +94,18 @@ spec:
     content: |
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
-      net.core.somaxconn = 100000
-      net.netfilter.nf_conntrack_max = 1000000
-      net.ipv4.tcp_max_syn_backlog = 100000
-      net.core.netdev_max_backlog = 100000
+      net.core.somaxconn = 131072
+      net.netfilter.nf_conntrack_max = 1048576
+      net.ipv4.tcp_max_syn_backlog = 65536
+      net.core.netdev_max_backlog = 524288
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 134217728
-      net.core.wmem_max = 134217728
-      net.ipv4.tcp_rmem = 4096 12582912 67108864
-      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      net.core.rmem_max = 131072
+      net.core.wmem_max = 131072
+      net.ipv4.tcp_mem = 262144 524288 1048576
+      net.ipv4.tcp_rmem = 4096 65536 131072
+      net.ipv4.tcp_wmem = 4096 65536 131072
       EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
@@ -131,17 +133,18 @@ spec:
     content: |
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
-      net.core.somaxconn = 100000
-      net.netfilter.nf_conntrack_max = 1000000
-      net.ipv4.tcp_max_syn_backlog = 100000
-      net.core.netdev_max_backlog = 100000
+      net.core.somaxconn = 131072
+      net.netfilter.nf_conntrack_max = 1048576
+      net.ipv4.tcp_max_syn_backlog = 65536
+      net.core.netdev_max_backlog = 524288
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 134217728
-      net.core.wmem_max = 134217728
-      net.ipv4.tcp_rmem = 4096 12582912 67108864
-      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      net.core.rmem_max = 131072
+      net.core.wmem_max = 131072
+      net.ipv4.tcp_mem = 262144 524288 1048576
+      net.ipv4.tcp_rmem = 4096 65536 131072
+      net.ipv4.tcp_wmem = 4096 65536 131072
       EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -96,7 +96,7 @@ spec:
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 131072
       net.netfilter.nf_conntrack_max = 1048576
-      net.ipv4.tcp_max_syn_backlog = 65536
+      net.ipv4.tcp_max_syn_backlog = 131072
       net.core.netdev_max_backlog = 524288
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
@@ -135,7 +135,7 @@ spec:
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 131072
       net.netfilter.nf_conntrack_max = 1048576
-      net.ipv4.tcp_max_syn_backlog = 65536
+      net.ipv4.tcp_max_syn_backlog = 131072
       net.core.netdev_max_backlog = 524288
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -94,6 +94,7 @@ spec:
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 100000
+      net.netfilter.nf_conntrack_max = 1000000
       net.ipv4.tcp_max_syn_backlog = 100000
       net.core.netdev_max_backlog = 100000
       net.ipv4.ip_local_port_range = 1024 65535
@@ -131,6 +132,7 @@ spec:
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
       net.core.somaxconn = 100000
+      net.netfilter.nf_conntrack_max = 1000000
       net.ipv4.tcp_max_syn_backlog = 100000
       net.core.netdev_max_backlog = 100000
       net.ipv4.ip_local_port_range = 1024 65535

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -128,12 +128,14 @@ redis:
   securityContext:
     sysctls:
       - name: net.core.somaxconn
-        value: "100000"
+        value: "131072"
       - name: net.netfilter.nf_conntrack_max
-        value: "1000000"
+        value: "1048576"
   master:
+    persistence:
+      enabled: false
     extraFlags:
-      - "--maxclients 100000"
+      - "--maxclients 131072"
     podAnnotations:
       cni: flannel
     resources:

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -130,7 +130,7 @@ redis:
       - name: net.core.somaxconn
         value: "100000"
       - name: net.netfilter.nf_conntrack_max
-        value: "100000"
+        value: "1000000"
   master:
     extraFlags:
       - "--maxclients 100000"


### PR DESCRIPTION
After a lot of investigation, let me explain what I've done here, parameter by parameter.

**`net.core.somaxconn = 131072`**

Bumped up to 128Ki -- for a good binary value. Note: this is the number of incoming sockets awaiting to be accepted, not the maximum number of connections we can maintain. It's a misnomer...

**`net.netfilter.nf_conntrack_max = 1048576`**

Let's use binary values.

**`net.ipv4.tcp_max_syn_backlog = 131072`**

This is the maximum number of incoming connections in SYN state. I don't think it needs to be so high. I was going to suggest 64Ki, but it doesn't hurt us to have a higher value, since our workloads are very bursty. So I rounded up to the next meaningful binary value.

**`net.core.netdev_max_backlog = 524288`**

This is the number of frames that can be outstanding before being consumed from the networking device. We can afford for this to be higher.

**`net.core.rmem_max = 131072`**
**`net.core.wmem_max = 131072`**

Maximum read and write buffer sizes in bytes. Setting them to 128KiB. We are interested in supporting a large number of concurrent connections, but at the same time we want this number to be similar to the defaults found in the wild. Rationale: we want our test workloads to get realistic congestion control. A quick Google search reveals the defaults in Linux environments tend to be 128KiB.

**`net.ipv4.tcp_mem = 262144 524288 1048576`**

These are the low, pressure, and max watermarks for total memory usage the TCP stack -- in memory pages (not bytes). Each page is 4KiB, so our max is 4GiB.

**`net.ipv4.tcp_rmem = 4096 65536 131072`**
**`net.ipv4.tcp_wmem = 4096 65536 131072`**

These are the low, pressure, and max watermarks for buffers. We allow a max of 128KiB. Under memory pressure, buffers will be theoretically pruned to their lowest (4KiB), which would allow 1Mi minimally sized buffers, and because each connection users two buffers, we're looking at a max of 512Ki connections.