### PR TITLE
fix: close response and read full

### DIFF
--- a/sdk/runtime/runner.go
+++ b/sdk/runtime/runner.go
@@ -156,7 +156,11 @@ func setupMetrics(ctx context.Context, runenv *RunEnv) (doneCh chan error) {
 				if err != nil {
 					continue
 				}
-				_, _ = resp.Body.Read(b)
+				_, err = io.ReadFull(resp.Body, b)
+				resp.Body.Close()
+				if err != nil {
+					continue
+				}
 				if string(b) == "OK" {
 					break Outer
 				}


### PR DESCRIPTION
1. Read may just read a single byte.
2. Make sure to actually close the body to avoid leaking.