### PR TITLE
Fix/separate k8s infrastructure from plans

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -144,12 +144,55 @@ spec:
       net.ipv4.tcp_rmem = 4096 12582912 67108864
       net.ipv4.tcp_wmem = 4096 12582912 67108864
       EOT
+  cloudLabels:
+    testground.purpose: plan-node
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
+    testground.purpose: plan-node
+  role: Node
+  subnets:
+  - ${ZONE}
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${NAME}
+  name: tginfra
+spec:
+  additionalUserData:
+  - name: myscript.sh
+    type: text/x-shellscript
+    content: |
+      #!/bin/sh
+      cat <<EOT >> /etc/sysctl.d/999-testground.conf
+      net.core.somaxconn = 100000
+      net.ipv4.tcp_max_syn_backlog = 100000
+      net.core.netdev_max_backlog = 100000
+      net.ipv4.ip_local_port_range = 1024 65535
+      net.ipv4.tcp_tw_recycle = 1
+      net.ipv4.tcp_tw_reuse = 1
+      net.core.rmem_max = 134217728
+      net.core.wmem_max = 134217728
+      net.ipv4.tcp_rmem = 4096 12582912 67108864
+      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      EOT
+  cloudLabels:
+    testground.purpose: infra-node
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: c5.2xlarge
+  maxSize: 2
+  minSize: 2
+  nodeLabels:
+    kops.k8s.io/instancegroup: tginfra
+    testground.purpose: infra-node
   role: Node
   subnets:
   - ${ZONE}

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -145,14 +145,14 @@ spec:
       net.ipv4.tcp_wmem = 4096 12582912 67108864
       EOT
   cloudLabels:
-    testground.purpose: plan-node
+    testground.nodetype: plan
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: ${WORKER_NODES}
   minSize: ${WORKER_NODES}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
-    testground.purpose: plan-node
+    testground.nodetype: plan
   role: Node
   subnets:
   - ${ZONE}
@@ -185,14 +185,14 @@ spec:
       net.ipv4.tcp_wmem = 4096 12582912 67108864
       EOT
   cloudLabels:
-    testground.purpose: infra-node
+    testground.nodetype: infra
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
   maxSize: 2
   minSize: 2
   nodeLabels:
     kops.k8s.io/instancegroup: tginfra
-    testground.purpose: infra-node
+    testground.nodetype: infra
   role: Node
   subnets:
   - ${ZONE}

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -178,16 +178,18 @@ spec:
     content: |
       #!/bin/sh
       cat <<EOT >> /etc/sysctl.d/999-testground.conf
-      net.core.somaxconn = 100000
-      net.ipv4.tcp_max_syn_backlog = 100000
-      net.core.netdev_max_backlog = 100000
+      net.core.somaxconn = 131072
+      net.netfilter.nf_conntrack_max = 1048576
+      net.ipv4.tcp_max_syn_backlog = 131072
+      net.core.netdev_max_backlog = 524288
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 134217728
-      net.core.wmem_max = 134217728
-      net.ipv4.tcp_rmem = 4096 12582912 67108864
-      net.ipv4.tcp_wmem = 4096 12582912 67108864
+      net.core.rmem_max = 131072
+      net.core.wmem_max = 131072
+      net.ipv4.tcp_mem = 262144 524288 1048576
+      net.ipv4.tcp_rmem = 4096 65536 131072
+      net.ipv4.tcp_wmem = 4096 65536 131072
       EOT
   cloudLabels:
     testground.nodetype: infra

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -52,7 +52,12 @@ kops create secret --name $NAME sshpublickey admin -i $PUBKEY
 kops update cluster $NAME --yes
 
 # wait for worker nodes and master to be ready
-kops validate cluster --wait 10m || echo cluster was not ready after 10 minutes. && exit 2
+kops validate cluster --wait 10m
+if [ $? -ne 0 ]
+then
+	echo "cluster was not ready after 10 minutes."
+	exit 3
+fi
 
 echo "Cluster nodes are Ready"
 echo

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -52,10 +52,7 @@ kops create secret --name $NAME sshpublickey admin -i $PUBKEY
 kops update cluster $NAME --yes
 
 # wait for worker nodes and master to be ready
-echo "Wait for Cluster nodes to be Ready..."
-echo
-READY_NODES=0
-while [ "$READY_NODES" -ne $(($WORKER_NODES + 1)) ]; do READY_NODES=$(kubectl get nodes 2>/dev/null | grep -v NotReady | grep Ready | wc -l || true); echo "Got $READY_NODES ready nodes"; sleep 5; done;
+kops validate cluster --wait 10m || echo cluster was not ready after 10 minutes. && exit 2
 
 echo "Cluster nodes are Ready"
 echo

--- a/infra/k8s/sidecar.yaml
+++ b/infra/k8s/sidecar.yaml
@@ -70,4 +70,6 @@ spec:
       - name: cnibin
         hostPath:
           path: /opt/cni/bin
+      nodeSelector:
+        testground.nodetype: plan
 

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -32,6 +32,8 @@ prometheus-operator:
     enabled: false
   grafana:
     adminPassword: testground
+    nodeSelector:
+      testground.nodetype: infra
     sidecar:
       dashboards:
         enabled: true
@@ -75,6 +77,8 @@ prometheus-operator:
       spec:
         serviceMonitorNamespaceSelector:
           any: true
+      nodeSelector:
+        testground.nodetype: infra
     resources:
       requests:
         memory: 2000Mi
@@ -99,6 +103,8 @@ prometheus-pushgateway:
     namespace: default
   networkPolicy:
     allowAll: true
+  nodeSelector:
+    testground.nodetype: infra
   podAnnotations:
     cni: flannel
   resources:
@@ -134,6 +140,8 @@ redis:
   master:
     extraFlags:
       - "--maxclients 100000"
+    nodeSelector:
+      testground.nodetype: infra 
     podAnnotations:
       cni: flannel
     resources:

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -367,7 +367,7 @@ func (c *ClusterK8sRunner) healthcheckSidecar() (sidecarCheck api.HealthcheckIte
 	defer c.pool.Release(client)
 
 	res, err := client.CoreV1().Nodes().List(metav1.ListOptions{
-		LabelSelector: "kubernetes.io/role=node",
+		LabelSelector: "testground.nodetype=plan",
 	})
 	if err != nil {
 		sidecarCheck.Message = err.Error()
@@ -836,6 +836,7 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 					},
 				},
 			},
+			NodeSelector: map[string]string{"testground.nodetype": "plan"},
 		},
 	}
 


### PR DESCRIPTION
fix: https://github.com/ipfs/testground/issues/780

This creates a separate autoscaling group (tginfra) on which redis, prometheus, prometheus-pushgateway, and grafana are isolated away from other nodes. I created a label `testground.nodetype` 

In this diff, the WORKER_NODES environment variable corresponds only for the autoscaling group with the label `testground.nodetype=plan` 

Sidecar and plan pods are restricted to `testground.nodetype=plan`

testground infrastructure is restricted to `testground.nodetype=infra`