### PR TITLE
allow ecr access from k8s

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -7,6 +7,15 @@ spec:
   api:
     loadBalancer:
       type: Public
+  additionalPolicies:
+    node: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": ["ecr:*"],
+          "Resource": ["*"]
+        }
+      ]
   authorization:
     rbac: {}
   channel: stable


### PR DESCRIPTION
We need ECR access once we move the `testground daemon` to Kubernetes (so that it can build and push images).

Merging this earlier would be helpful when iterating on various features on Testground, so that I don't have to maintain multiple clusters (one with ECR access, one without (for `master`)), but rather iterate faster.