### PR TITLE
reproduce redis readiness probe failure

### DIFF
--- a/manifests/benchmarks.toml
+++ b/manifests/benchmarks.toml
@@ -66,5 +66,5 @@ name = "subtree"
 instances = { min = 1, max = 20000, default = 2 }
 
   [testcases.params]
-  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 50 }
+  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 10 }
   subtree_test_timeout_secs  = { type = "int", desc = "subtree testcase timeout", unit = "seconds", default = 300 }

--- a/manifests/benchmarks.toml
+++ b/manifests/benchmarks.toml
@@ -66,5 +66,5 @@ name = "subtree"
 instances = { min = 1, max = 20000, default = 2 }
 
   [testcases.params]
-  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 20 }
+  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 50 }
   subtree_test_timeout_secs  = { type = "int", desc = "subtree testcase timeout", unit = "seconds", default = 300 }

--- a/manifests/benchmarks.toml
+++ b/manifests/benchmarks.toml
@@ -66,5 +66,5 @@ name = "subtree"
 instances = { min = 1, max = 20000, default = 2 }
 
   [testcases.params]
-  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 200 }
+  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 20 }
   subtree_test_timeout_secs  = { type = "int", desc = "subtree testcase timeout", unit = "seconds", default = 300 }

--- a/manifests/benchmarks.toml
+++ b/manifests/benchmarks.toml
@@ -66,5 +66,5 @@ name = "subtree"
 instances = { min = 1, max = 20000, default = 2 }
 
   [testcases.params]
-  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 2000 }
+  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 200 }
   subtree_test_timeout_secs  = { type = "int", desc = "subtree testcase timeout", unit = "seconds", default = 300 }

--- a/plans/benchmarks/benchmarks.go
+++ b/plans/benchmarks/benchmarks.go
@@ -241,8 +241,10 @@ func SubtreeBench(runenv *runtime.RunEnv) error {
 	// Create tests ranging from 64B to 4KiB.
 	// Note: anything over 1500 is likely to have ethernet fragmentation.
 	var tests []*testSpec
-	for size := 64; size <= 664; size++ {
-		name := fmt.Sprintf("subtree_time_%d_bytes", size)
+	//for size := 64; size <= 664; size++ {
+	for testid := 1; testid <= 600; testid++ {
+		size := 16
+		name := fmt.Sprintf("subtree_time_%d_%d_bytes", testid, size)
 		d := make([]byte, 0, size)
 		rand.Read(d)
 		data := string(d)
@@ -345,10 +347,10 @@ func SubtreeBench(runenv *runtime.RunEnv) error {
 			})
 		}
 
+		eg.Wait()
+
 		runenv.RecordMessage("sleeping 30sec")
 		time.Sleep(30 * time.Second)
-
-		eg.Wait()
 	}
 
 	return nil

--- a/plans/benchmarks/benchmarks.go
+++ b/plans/benchmarks/benchmarks.go
@@ -242,7 +242,7 @@ func SubtreeBench(runenv *runtime.RunEnv) error {
 	// Note: anything over 1500 is likely to have ethernet fragmentation.
 	var tests []*testSpec
 	for testid := 1; testid <= 500; testid++ {
-		size := 256
+		size := 1
 		name := fmt.Sprintf("subtree_time_%d_%d_bytes", testid, size)
 		d := make([]byte, 0, size)
 		rand.Read(d)

--- a/sdk/sync/subscription.go
+++ b/sdk/sync/subscription.go
@@ -89,6 +89,7 @@ func (s *subscription) process() {
 	args := &redis.XReadArgs{
 		Streams: []string{key, "0"},
 		Block:   0,
+		Count:   5,
 	}
 
 	var last redis.XMessage


### PR DESCRIPTION
```
testground run single benchmarks/subtree \
    --builder=docker:go \
    --runner=cluster:k8s \
    --build-cfg bypass_cache=true \
    --build-cfg push_registry=true \
    --build-cfg registry_type=aws \
    --run-cfg keep_service=false \
    --instances=120 --collect
```