### PR TITLE
default container limits

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -62,6 +62,12 @@ fi
 echo "Cluster nodes are Ready"
 echo
 
+echo "Install default container limits"
+echo
+
+kubectl apply -f ./limit-range/limit-range.yaml
+
+
 echo "Install EFS..."
 
 vpcId=`aws ec2 describe-vpcs --region=$AWS_REGION --filters Name=tag:Name,Values=$NAME --output text | awk '/VPCS/ { print $8 }'`

--- a/infra/k8s/limit-range/limit-range.yaml
+++ b/infra/k8s/limit-range/limit-range.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-pod-limits
+spec:
+  limits:
+  - default:
+      memory: 256Mi
+      cpu: 100m
+    defaultRequest:
+      memory: 256Mi
+      cpu: 100m
+    type: Container

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -79,10 +79,10 @@ prometheus-operator:
           any: true
       nodeSelector:
         testground.nodetype: infra
-    resources:
-      requests:
-        memory: 2000Mi
-        cpu: 2000m
+      resources:
+        requests:
+          memory: 2000Mi
+          cpu: 2000m
 
 
 # Changes from defaults:


### PR DESCRIPTION
Addresses https://github.com/ipfs/testground/issues/819

---

Ideally we don't want the OS OOM killer to kick in at any time, so we want to limit the resources on all containers with default.

These defaults can be overwritten by the pods themselves, but if a pod/container doesn't specify limits, it will use these.

TODO:
- [x] we probably want to amend prometheus container before merging this, otherwise it will get killed periodically I guess