### PR TITLE
redis qos guaranteed - set both requests and limits

### DIFF
--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -128,6 +128,13 @@ redis:
     serviceMonitor:
       enabled: true
       namespace: default
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 200m
+      limits:
+        memory: 256Mi
+        cpu: 200m
   cluster:
     enabled: false
   usePassword: false
@@ -143,10 +150,13 @@ redis:
     extraFlags:
       - "--maxclients 131072"
     nodeSelector:
-      testground.nodetype: infra 
+      testground.nodetype: infra
     podAnnotations:
       cni: flannel
     resources:
       requests:
+        memory: 13000Mi
+        cpu: 6500m
+      limits:
         memory: 13000Mi
         cpu: 6500m


### PR DESCRIPTION
I think it is better if our `redis` pod has `QoS guaranteed`, rather than `QoS burstable`.

WDYT?

---

I haven't seen any manifestation in terms of performance, but under system load, these classifications would get into effect I guess.

https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6

https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed