### PR TITLE
client/daemon timeout increase

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -55,8 +55,8 @@ func New(listenAddr string) (srv *Daemon, err error) {
 	srv.doneCh = make(chan struct{})
 	srv.server = &http.Server{
 		Handler:      r,
-		WriteTimeout: 600 * time.Second,
-		ReadTimeout:  600 * time.Second,
+		WriteTimeout: 1200 * time.Second,
+		ReadTimeout:  1200 * time.Second,
 	}
 
 	srv.l, err = net.Listen("tcp", listenAddr)


### PR DESCRIPTION
This is essentially limiting our testplan runs to 10min, because when the HTTP client times out, it canceles the requests/ctx, which gets propagated to k8s and it terminates the run.

---

```
Apr  7 23:15:35.107735  DEBUG   testplan pods state     {"req_id": "155c04aa", "runner": "cluster:k8s", "run_id": "8fa68e09033b", "running_for": "9m59.357737694s", "succeeded": 0, "running": 1000, "pending": 0, "failed": 0, "unknown": 0}
Apr  7 23:16:01.011496  INFO    run canceled    {"req_id": "155c04aa", "plan": "benchmarks", "case": "subtree", "runner": "cluster:k8s", "instances": 1000}
Apr  7 23:16:01.011667  WARN    engine run error: context canceled      {"req_id": "155c04aa"}
2020-04-08 01:16:01.011697 +0200 CEST m=+648.559788583 write error: write tcp [::1]:8080->[::1]:60198: i/o timeout
Apr  7 23:16:01.011762  ERROR   could not write error response  {"err": "write tcp [::1]:8080->[::1]:60198: i/o timeout"}
Apr  7 23:16:01.011786  DEBUG   request handled {"ruid": "155c04aa", "command": "run"}
```

---