### PR TITLE
move prometheus-operator to infra node. fix requests and affinity

### DIFF
--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -28,10 +28,48 @@ prometheus-operator:
           cni: flannel
     podAnnotations:
       cni: flannel
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - redis
+          topologyKey: "kubernetes.io/hostname"
+    nodeSelector:
+      testground.nodetype: infra
+    resources:
+      requests:
+        memory: 512Mi
+        cpu: 500m
+      limits:
+        memory: 512Mi
+        cpu: 500m
   alertmanager:
     enabled: false
   grafana:
     adminPassword: testground
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - redis
+          topologyKey: "kubernetes.io/hostname"
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - prometheus-operator-operator
+          topologyKey: "kubernetes.io/hostname"
     nodeSelector:
       testground.nodetype: infra
     sidecar:
@@ -47,6 +85,16 @@ prometheus-operator:
         enabled: true
     podAnnotations:
       cni: flannel
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - prometheus-operator-operator
+          topologyKey: "kubernetes.io/hostname"
   kubeProxy:
     serviceMonitor:
       https: false
@@ -77,12 +125,34 @@ prometheus-operator:
       spec:
         serviceMonitorNamespaceSelector:
           any: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - redis
+            topologyKey: "kubernetes.io/hostname"
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - prometheus-operator-operator
+            topologyKey: "kubernetes.io/hostname"
       nodeSelector:
         testground.nodetype: infra
       resources:
         requests:
-          memory: 2000Mi
-          cpu: 2000m
+          memory: 4000Mi
+          cpu: 4000m
+        limits:
+          memory: 4000Mi
+          cpu: 4000m
 
 
 # Changes from defaults:
@@ -103,6 +173,25 @@ prometheus-pushgateway:
     namespace: default
   networkPolicy:
     allowAll: true
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - redis
+        topologyKey: "kubernetes.io/hostname"
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - prometheus-operator-operator
+        topologyKey: "kubernetes.io/hostname"
   nodeSelector:
     testground.nodetype: infra
   podAnnotations:
@@ -110,7 +199,10 @@ prometheus-pushgateway:
   resources:
     requests:
       memory: 2000Mi
-      cpu: 2000m
+      cpu: 1000m
+    limits:
+      memory: 2000Mi
+      cpu: 1000m
 
 
 # Changes from defaults:


### PR DESCRIPTION
Now that we have 2 nodes for testground infra, we need to be a bit more careful about where we schedule what - if `monitoring` pods (push-gateways, prometheus, grafana, operator, etc.) are spread between the 2 machines, we don't have enough space for Redis.

Therefore I am adding a few affinity and anti-affinity rules in order to make sure that Redis gets one host, and the monitoring pods get another host. The result is:

Redis host:
```
Non-terminated Pods:          (8 in total)
  Namespace                   Name                                                         CPU Requests  CPU Limits   Memory Requests  Memory Limits  AGE
  ---------                   ----                                                         ------------  ----------   ---------------  -------------  ---
  default                     dummy-fnjr7                                                  100m (1%)     100m (1%)    256Mi (1%)       256Mi (1%)     34m
  default                     testground-infra-prometheus-node-exporter-td8fj              100m (1%)     100m (1%)    256Mi (1%)       256Mi (1%)     2m22s
  default                     testground-infra-redis-master-0                              6700m (83%)   6700m (83%)  13256Mi (86%)    13256Mi (86%)  2m22s
  kube-system                 genie-plugin-x7h8h                                           0 (0%)        0 (0%)       0 (0%)           0 (0%)         34m
  kube-system                 kube-dns-autoscaler-594dcb44b5-7n25m                         20m (0%)      0 (0%)       10Mi (0%)        0 (0%)         40m
  kube-system                 kube-flannel-ds-7dstx                                        100m (1%)     0 (0%)       100Mi (0%)       100Mi (0%)     38m
  kube-system                 kube-proxy-ip-172-20-62-115.eu-central-1.compute.internal    100m (1%)     0 (0%)       0 (0%)           0 (0%)         37m
  kube-system                 weave-net-6wklr                                              10m (0%)      0 (0%)       0 (0%)           0 (0%)         34m
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                    Requests       Limits
  --------                    --------       ------
  cpu                         7130m (89%)    6900m (86%)
  memory                      13878Mi (90%)  13868Mi (90%)
  ephemeral-storage           0 (0%)         0 (0%)
  attachable-volumes-aws-ebs  0
```

Monitoring host:
```
Non-terminated Pods:          (11 in total)
  Namespace                   Name                                                        CPU Requests  CPU Limits   Memory Requests  Memory Limits  AGE
  ---------                   ----                                                        ------------  ----------   ---------------  -------------  ---
  default                     dummy-4mwl8                                                 100m (1%)     100m (1%)    256Mi (1%)       256Mi (1%)     35m
  default                     prometheus-pushgateway-5546c8d9d8-2r229                     1 (12%)       1 (12%)      2000Mi (13%)     2000Mi (13%)   2m54s
  default                     prometheus-testground-infra-prometheu-prometheus-0          4200m (52%)   4200m (52%)  4050Mi (26%)     4050Mi (26%)   2m39s
  default                     testground-infra-grafana-55f9b9b9fb-495bp                   300m (3%)     300m (3%)    768Mi (4%)       768Mi (4%)     2m54s
  default                     testground-infra-kube-state-metrics-646c85bb8b-5667x        100m (1%)     100m (1%)    256Mi (1%)       256Mi (1%)     2m54s
  default                     testground-infra-prometheu-operator-6c8dc4fd4d-888tp        600m (7%)     600m (7%)    768Mi (4%)       768Mi (4%)     2m54s
  default                     testground-infra-prometheus-node-exporter-xfp2r             100m (1%)     100m (1%)    256Mi (1%)       256Mi (1%)     2m54s
  kube-system                 genie-plugin-bf6mb                                          0 (0%)        0 (0%)       0 (0%)           0 (0%)         35m
  kube-system                 kube-flannel-ds-4shxd                                       100m (1%)     0 (0%)       100Mi (0%)       100Mi (0%)     39m
  kube-system                 kube-proxy-ip-172-20-35-80.eu-central-1.compute.internal    100m (1%)     0 (0%)       0 (0%)           0 (0%)         39m
  kube-system                 weave-net-jw99m                                             10m (0%)      0 (0%)       0 (0%)           0 (0%)         35m
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                    Requests      Limits
  --------                    --------      ------
  cpu                         6610m (82%)   6400m (80%)
  memory                      8454Mi (54%)  8454Mi (54%)
  ephemeral-storage           0 (0%)        0 (0%)
  attachable-volumes-aws-ebs  0             0
```