### PR TITLE
move weave and sidecar, prior to installing testground-infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,3 @@ plans/**/go.sum
 .history
 
 # End of https://www.gitignore.io/api/go,visualstudiocode
-
-## tarballs
-# test outputs and unextracted helm charts are both gzipped tar files
-# with a tgz extension.
-*.tgz

--- a/infra/k8s/efs-terraform/.gitignore
+++ b/infra/k8s/efs-terraform/.gitignore
@@ -1,2 +1,0 @@
-.terraform
-terraform.tfstate*

--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -127,24 +127,28 @@ envsubst <./efs/manifest.yaml.spec >$EFS_MANIFEST_SPEC
 kubectl apply -f ./efs/rbac.yaml \
               -f $EFS_MANIFEST_SPEC
 
-# monitoring and redis.
-echo "Installing Testground infrastructure - prometheus, pushgateway, redis, dashboards"
+echo "Install Weave, CNI-Genie, Sidecar Daemonset..."
+echo
+
+kubectl apply -f ./kops-weave/weave.yml \
+              -f ./kops-weave/genie-plugin.yaml \
+              -f ./kops-weave/dummy.yml \
+              -f ./sidecar.yaml
+
+echo "Installing Prometheus"
 helm install prometheus-operator stable/prometheus-operator -f prom-operator.yml
+
+echo "Installing Prometheus Pushgateway, Redis, Grafana dashboards"
 pushd testground-infra
 helm dep build
 helm install testground-infra .
 popd
 
-echo "Install Weave, CNI-Genie, s3bucket DaemonSet, Sidecar Daemonset..."
+echo "Install Weave service monitor..."
 echo
 
-kubectl apply -f ./kops-weave/weave.yml \
-              -f ./kops-weave/genie-plugin.yaml \
-              -f ./kops-weave/weave-metrics-service.yml \
-              -f ./kops-weave/weave-service-monitor.yml \
-              -f ./kops-weave/dummy.yml \
-              -f ./sidecar.yaml
-
+kubectl apply -f ./kops-weave/weave-metrics-service.yml \
+              -f ./kops-weave/weave-service-monitor.yml
 
 echo "Wait for Sidecar to be Ready..."
 echo


### PR DESCRIPTION
Routes before we install `sidecar`:

```
default via 172.20.32.1 dev eth0
100.96.0.0/24 via 100.96.0.0 dev flannel.1 onlink
100.96.1.0/24 via 100.96.1.0 dev flannel.1 onlink
100.96.2.0/24 via 100.96.2.0 dev flannel.1 onlink
100.96.3.0/24 via 100.96.3.0 dev flannel.1 onlink
100.96.4.0/24 via 100.96.4.0 dev flannel.1 onlink
100.96.6.0/24 via 100.96.6.0 dev flannel.1 onlink
100.96.7.0/24 via 100.96.7.0 dev flannel.1 onlink
100.96.8.0/24 via 100.96.8.0 dev flannel.1 onlink
100.96.9.0/24 via 100.96.9.0 dev flannel.1 onlink
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
172.20.32.0/19 dev eth0 proto kernel scope link src 172.20.55.130
```

---

Routes after we install sidecar (or at least the initContainer runs):

```
default via 172.20.32.1 dev eth0
100.64.0.0/16 via 100.96.5.1 dev cni0
100.96.0.0/24 via 100.96.0.0 dev flannel.1 onlink
100.96.1.0/24 via 100.96.1.0 dev flannel.1 onlink
100.96.2.0/24 via 100.96.2.0 dev flannel.1 onlink
100.96.3.0/24 via 100.96.3.0 dev flannel.1 onlink
100.96.4.0/24 via 100.96.4.0 dev flannel.1 onlink
100.96.5.0/24 dev cni0 proto kernel scope link src 100.96.5.1
100.96.6.0/24 via 100.96.6.0 dev flannel.1 onlink
100.96.7.0/24 via 100.96.7.0 dev flannel.1 onlink
100.96.8.0/24 via 100.96.8.0 dev flannel.1 onlink
100.96.9.0/24 via 100.96.9.0 dev flannel.1 onlink
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 linkdown
172.20.32.0/19 dev eth0 proto kernel scope link src 172.20.55.130
```