### PR TITLE
docker: filter labels by value, not by regex

### DIFF
--- a/pkg/docker/manager.go
+++ b/pkg/docker/manager.go
@@ -181,9 +181,7 @@ func (m *Manager) Watch(ctx context.Context, worker WorkerFn, labels ...string) 
 
 	listFilter := filters.NewArgs()
 	for _, l := range labels {
-		// Filter by exact label names using a regex.
-		exactLabel := fmt.Sprintf("^%s$", l)
-		listFilter.Add("label", exactLabel)
+		listFilter.Add("label", l)
 	}
 	nodes, err := m.Client.ContainerList(ctx, types.ContainerListOptions{
 		Quiet:   true,


### PR DESCRIPTION
Docker filters docker container names by regex, but not labels.