### PR TITLE
accept any case of boolean tRuE

### DIFF
--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -303,8 +303,8 @@ func (re *RunParams) IntParam(name string) int {
 
 // BooleanParam returns the Boolean value of the parameter, or false if not passed
 func (re *RunParams) BooleanParam(name string) bool {
-	s := re.TestInstanceParams[name]
-	return s == "true"
+	s, ok := re.TestInstanceParams[name]
+	return ok && strings.ToLower(s) == "true"
 }
 
 // StringArrayParam returns an array of string parameter, or an empty array


### PR DESCRIPTION
We ran into an issue in the pubsub test plans where Python outputs `True` (uppercase T) but testground only parses `true` (lowercase t)