### PR TITLE
rm TEST_CASE_SEQ as a selector; replace with test case name.

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -219,23 +219,14 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv) error {
-   test.MyTest1,
-   test.MyTest2,
+var testcases = map[string]runtime.TestCaseFn {
+   "test-1": test.MyTest1,
+   "test-2": test.MyTest2,
    // add any other tests you have in ./test
 }
 
 func main() {
-	runtime.Invoke(run)
-}
-
-func run(runenv *runtime.RunEnv) error {
-	if runenv.TestCaseSeq < 0 {
-		panic("test case sequence number not set")
-	}
-
-	// Demux to the right test case.
-	return testCases[runenv.TestCaseSeq](runenv)
+	runtime.InvokeMap(testcases)
 }
 ```
 

--- a/manifests/bitswap-tuning.toml
+++ b/manifests/bitswap-tuning.toml
@@ -28,7 +28,6 @@ enabled = true
 [run_strategies."cluster:swarm"]
 enabled = true
 
-# seq 0
 [[testcases]]
 name = "transfer"
 instances = { min = 2, max = 64, default = 2 }
@@ -47,7 +46,6 @@ instances = { min = 2, max = 64, default = 2 }
   bandwidth_mb = { type = "int", desc = "bandwidth", unit = "Mib", default = 1024 }
   parallel_gen_mb = { type = "int", desc = "maximum allowed size of seed data to generate in parallel", unit = "Mib", default = 100 }
 
-# seq 1
 [[testcases]]
 name = "fuzz"
 instances = { min = 2, max = 64, default = 2 }

--- a/manifests/dht.toml
+++ b/manifests/dht.toml
@@ -31,7 +31,6 @@ enabled = true
 [run_strategies."cluster:k8s"]
 enabled = true
 
-# seq 0
 [[testcases]]
 name = "find-peers"
 instances = { min = 16, max = 10000, default = 16 }
@@ -55,7 +54,6 @@ instances = { min = 16, max = 10000, default = 16 }
 
   n_find_peers = { type = "int", desc = "number of peers to find", unit = "peers", default = 1 }
 
-# seq 1
 [[testcases]]
 name = "find-providers"
 instances = { min = 16, max = 10000, default = 16 }
@@ -84,7 +82,6 @@ instances = { min = 16, max = 10000, default = 16 }
   #p_resolving = { type = "int", desc = "", unit = "% of nodes" }
   #p_failing = { type = "int", desc = "", unit = "% of nodes" }
 
-# seq 2
 [[testcases]]
 name = "provide-stress"
 instances = { min = 16, max = 250, default = 16 }
@@ -97,7 +94,6 @@ instances = { min = 16, max = 250, default = 16 }
   n_provides = { type = "int", desc = "number of times to provide", unit = "int" }
   i_provides = { type = "int", desc = "interval between each provide", unit = "seconds" }
 
-# seq 3
 [[testcases]]
 name = "store-get-value"
 instances = { min = 16, max = 250, default = 16 }
@@ -106,7 +102,6 @@ roles = ["storer", "fetcher"]
   [testcases.params]
   bucket_size = { type = "int", desc = "bucket size", unit = "peers" }
 
-# seq 4
 [[testcases]]
 name = "get-closest-peers"
 instances = { min = 16, max = 10000, default = 16 }
@@ -132,7 +127,6 @@ instances = { min = 16, max = 10000, default = 16 }
   record_count   = { type = "int", desc = "number of records a peer provides", unit = "int", default = 0 }
   search_records = { type = "bool", desc = "node will search for records", unit = "bool", default = false }
 
-# seq 5
 [[testcases]]
 name = "bootstrap-network"
 instances = { min = 16, max = 10000, default = 16 }
@@ -154,7 +148,6 @@ undialable   = { type = "bool", desc = "node is undialable", unit = "bool", defa
 group_order  = { type = "int", desc = "the order in which the node is bootstrapped, may be tied with another node", unit ="int", default = 0}
 expect_dht   = { type = "bool", desc = "the node expects to be a dht server", unit ="bool", default = true}
 
-# seq 6
 [[testcases]]
 name = "all"
 instances = { min = 16, max = 10000, default = 16 }

--- a/manifests/placebo.toml
+++ b/manifests/placebo.toml
@@ -27,7 +27,6 @@ enabled = true
 [run_strategies."cluster:swarm"]
 enabled = true
 
-# seq 0
 [[testcases]]
 name = "ok"
 instances = { min = 1, max = 200, default = 1 }
@@ -35,7 +34,6 @@ instances = { min = 1, max = 200, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 1
 [[testcases]]
 name = "abort"
 instances = { min = 1, max = 250, default = 1 }
@@ -43,7 +41,6 @@ instances = { min = 1, max = 250, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 2
 [[testcases]]
 name = "metrics"
 instances = { min = 1, max = 250, default = 1 }
@@ -51,12 +48,10 @@ instances = { min = 1, max = 250, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 3
 [[testcases]]
 name = "panic"
 instances = { min = 1, max = 250, default = 1 }
 
-# seq 4
 [[testcases]]
 name = "stall"
 instances = { min = 1, max = 250, default = 1 }

--- a/pkg/api/definitions.go
+++ b/pkg/api/definitions.go
@@ -57,10 +57,10 @@ type TestCaseInstances struct {
 }
 
 // TestCaseByName returns a test case by name.
-func (tp *TestPlanDefinition) TestCaseByName(name string) (seq int, tc *TestCase, ok bool) {
-	for seq, tc := range tp.TestCases {
+func (tp *TestPlanDefinition) TestCaseByName(name string) (idx int, tc *TestCase, ok bool) {
+	for idx, tc = range tp.TestCases {
 		if tc.Name == name {
-			return seq, tc, true
+			return idx, tc, true
 		}
 	}
 	return -1, nil, false

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -53,8 +53,8 @@ type RunInput struct {
 	// run.
 	TestPlan *TestPlanDefinition
 
-	// Seq is the test case seq number to run.
-	Seq int
+	// TestCase is the the definition of the test case to run.
+	TestCase *TestCase
 
 	// TotalInstances is the total number of instances participating in this test case.
 	TotalInstances int

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -316,7 +316,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 	}
 
 	// Find the test case.
-	seq, tcase, ok := plan.TestCaseByName(testcase)
+	_, tcase, ok := plan.TestCaseByName(testcase)
 	if !ok {
 		return nil, fmt.Errorf("unrecognized test case %s in test plan %s", testcase, testplan)
 	}
@@ -418,7 +418,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 		RunnerConfig:   obj,
 		Directories:    e.envcfg,
 		TestPlan:       plan,
-		Seq:            seq,
+		TestCase:       tcase,
 		TotalInstances: int(comp.Global.TotalInstances),
 		Groups:         make([]api.RunGroup, 0, len(comp.Groups)),
 	}

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -144,16 +144,10 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 	podResourceCPU := resource.MustParse(cfg.PodResourceCPU)
 	podResourceMemory := resource.MustParse(cfg.PodResourceMemory)
 
-	// Sanity check.
-	if input.Seq < 0 || input.Seq >= len(input.TestPlan.TestCases) {
-		return nil, fmt.Errorf("invalid test case seq %d for plan %s", input.Seq, input.TestPlan.Name)
-	}
-
 	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
-		TestCase:          input.TestPlan.TestCases[input.Seq].Name,
+		TestCase:          input.TestCase.Name,
 		TestRun:           input.RunID,
-		TestCaseSeq:       input.Seq,
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -70,7 +70,6 @@ type ClusterSwarmRunner struct{}
 // the test has run.
 func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc.OutputWriter) (*api.RunOutput, error) {
 	var (
-		seq = input.Seq
 		log = ow.With("runner", "cluster:swarm", "run_id", input.RunID)
 		cfg = *input.RunnerConfig.(*ClusterSwarmRunnerConfig)
 	)
@@ -79,14 +78,9 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 	ctx, cancelFn := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancelFn()
 
-	// Sanity check.
-	if seq < 0 || seq >= len(input.TestPlan.TestCases) {
-		return nil, fmt.Errorf("invalid test case seq %d for plan %s", seq, input.TestPlan.Name)
-	}
-
 	// Get the test case.
 	var (
-		testcase = input.TestPlan.TestCases[seq]
+		testcase = input.TestCase
 		parent   = fmt.Sprintf("tg-%s-%s-%s", input.TestPlan.Name, testcase.Name, input.RunID)
 	)
 
@@ -95,7 +89,6 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          testcase.Name,
 		TestRun:           input.RunID,
-		TestCaseSeq:       seq,
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       true,
 	}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -173,18 +173,12 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 	defer r.lk.RUnlock()
 
 	var (
-		seq = input.Seq
 		log = ow.With("runner", "local:docker", "run_id", input.RunID)
 		err error
 	)
 
-	// Sanity check.
-	if seq < 0 || seq >= len(input.TestPlan.TestCases) {
-		return nil, fmt.Errorf("invalid test case seq %d for plan %s", seq, input.TestPlan.Name)
-	}
-
 	// Get the test case.
-	testcase := input.TestPlan.TestCases[seq]
+	testcase := input.TestCase
 
 	// Create a docker client.
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -197,7 +191,6 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		TestPlan:          input.TestPlan.Name,
 		TestCase:          testcase.Name,
 		TestRun:           input.RunID,
-		TestCaseSeq:       seq,
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -72,20 +72,14 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 
 	var (
 		plan = input.TestPlan
-		seq  = input.Seq
 		name = plan.Name
 	)
-
-	if seq >= len(plan.TestCases) {
-		return nil, fmt.Errorf("invalid sequence number %d for test %s", seq, name)
-	}
 
 	// Build a template runenv.
 	template := runtime.RunParams{
 		TestPlan:          input.TestPlan.Name,
-		TestCase:          input.TestPlan.TestCases[seq].Name,
+		TestCase:          input.TestCase.Name,
 		TestRun:           input.RunID,
-		TestCaseSeq:       seq,
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       false,
 		TestSubnet:        &runtime.IPNet{IPNet: *localSubnet},

--- a/plans/bitswap-tuning/main.go
+++ b/plans/bitswap-tuning/main.go
@@ -5,18 +5,17 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv) error{
-	test.Transfer,
-	test.Fuzz,
-}
-
 func main() {
 	runtime.Invoke(run)
 }
 
 func run(runenv *runtime.RunEnv) error {
-	if runenv.TestCaseSeq < 0 {
-		panic("test case sequence number not set")
+	switch c := runenv.TestCase; c {
+	case "transfer":
+		return test.Transfer(runenv)
+	case "fuzz":
+		return test.Fuzz(runenv)
+	default:
+		panic("unrecognized test case")
 	}
-	return testCases[runenv.TestCaseSeq](runenv)
 }

--- a/plans/dht/main.go
+++ b/plans/dht/main.go
@@ -5,23 +5,16 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv) error{
-	test.FindPeers,
-	test.FindProviders,
-	test.ProvideStress,
-	test.StoreGetValue,
-	test.GetClosestPeers,
-	test.BootstrapNetwork,
-	test.All,
+var testCases = map[string]runtime.TestCaseFn{
+	"find-peers": test.FindPeers,
+	"find-providers": test.FindProviders,
+	"provide-stress": test.ProvideStress,
+	"store-get-value": test.StoreGetValue,
+	"get-closest-peers": test.GetClosestPeers,
+	"bootstrap-network": test.BootstrapNetwork,
+	"all": test.All,
 }
 
 func main() {
-	runtime.Invoke(run)
-}
-
-func run(runenv *runtime.RunEnv) error {
-	if runenv.TestCaseSeq < 0 {
-		panic("test case sequence number not set")
-	}
-	return testCases[runenv.TestCaseSeq](runenv)
+	runtime.InvokeMap(testCases)
 }

--- a/plans/network/main.go
+++ b/plans/network/main.go
@@ -13,21 +13,17 @@ import (
 	"github.com/ipfs/testground/sdk/sync"
 )
 
-func main() {
-	runtime.Invoke(run)
+var testcases = map[string]runtime.TestCaseFn{
+	"ping-pong": pingpong,
 }
 
-func run(runenv *runtime.RunEnv) error {
+func main() {
+	runtime.InvokeMap(testcases)
+}
+
+func pingpong(runenv *runtime.RunEnv) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
-
-	if runenv.TestCaseSeq < 0 {
-		panic("test case sequence number not set")
-	}
-
-	if runenv.TestCaseSeq != 0 {
-		return fmt.Errorf("aborting")
-	}
 
 	runenv.RecordMessage("before sync.MustWatcherWriter")
 	watcher, writer := sync.MustWatcherWriter(ctx, runenv)

--- a/plans/placebo/main.go
+++ b/plans/placebo/main.go
@@ -14,14 +14,10 @@ func main() {
 }
 
 func run(runenv *runtime.RunEnv) error {
-	if runenv.TestCaseSeq < 0 {
-		panic("test case sequence number not set")
-	}
-
-	switch runenv.TestCaseSeq {
-	case 0:
+	switch c := runenv.TestCase; c {
+	case "ok":
 		return nil
-	case 2:
+	case "metrics":
 		// create context for cancelation
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -34,10 +30,10 @@ func run(runenv *runtime.RunEnv) error {
 
 		time.Sleep(time.Second * 5)
 		return nil
-	case 3:
+	case "panic":
 		// panic
 		panic(errors.New("this is an intentional panic"))
-	case 4:
+	case "stall":
 		// stall
 		time.Sleep(24 * time.Hour)
 		return nil

--- a/sdk/runtime/output.go
+++ b/sdk/runtime/output.go
@@ -88,7 +88,6 @@ func (m MetricValue) MarshalLogObject(oe zapcore.ObjectEncoder) error {
 func (r *RunParams) MarshalLogObject(oe zapcore.ObjectEncoder) error {
 	oe.AddString("plan", r.TestPlan)
 	oe.AddString("case", r.TestCase)
-	oe.AddInt("seq", r.TestCaseSeq)
 	if err := oe.AddReflected("params", r.TestInstanceParams); err != nil {
 		return err
 	}

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -16,7 +16,6 @@ import (
 const (
 	EnvTestBranch             = "TEST_BRANCH"
 	EnvTestCase               = "TEST_CASE"
-	EnvTestCaseSeq            = "TEST_CASE_SEQ"
 	EnvTestGroupID            = "TEST_GROUP_ID"
 	EnvTestGroupInstanceCount = "TEST_GROUP_INSTANCE_COUNT"
 	EnvTestInstanceCount      = "TEST_INSTANCE_COUNT"
@@ -67,7 +66,6 @@ type RunParams struct {
 	TestPlan    string `json:"plan"`
 	TestCase    string `json:"case"`
 	TestRun     string `json:"run"`
-	TestCaseSeq int    `json:"seq"`
 
 	TestRepo   string `json:"repo,omitempty"`
 	TestCommit string `json:"commit,omitempty"`
@@ -155,7 +153,6 @@ func (re *RunParams) ToEnvVars() map[string]string {
 	out := map[string]string{
 		EnvTestBranch:             re.TestBranch,
 		EnvTestCase:               re.TestCase,
-		EnvTestCaseSeq:            strconv.Itoa(re.TestCaseSeq),
 		EnvTestGroupID:            re.TestGroupID,
 		EnvTestGroupInstanceCount: strconv.Itoa(re.TestGroupInstanceCount),
 		EnvTestInstanceCount:      strconv.Itoa(re.TestInstanceCount),
@@ -235,7 +232,6 @@ func ParseRunParams(env []string) (*RunParams, error) {
 	return &RunParams{
 		TestBranch:             m[EnvTestBranch],
 		TestCase:               m[EnvTestCase],
-		TestCaseSeq:            toInt(m[EnvTestCaseSeq]),
 		TestGroupID:            m[EnvTestGroupID],
 		TestGroupInstanceCount: toInt(m[EnvTestGroupInstanceCount]),
 		TestInstanceCount:      toInt(m[EnvTestInstanceCount]),

--- a/sdk/runtime/runenv_test.go
+++ b/sdk/runtime/runenv_test.go
@@ -20,7 +20,6 @@ func TestParseKeyValues(t *testing.T) {
 			args: args{
 				[]string{
 					"TEST_INSTANCE_ROLE=",
-					"TEST_CASE_SEQ=0",
 					"TEST_ARTIFACTS=/artifacts",
 					"TEST_SIDECAR=true",
 				},

--- a/sdk/runtime/runenv_test.go
+++ b/sdk/runtime/runenv_test.go
@@ -27,7 +27,6 @@ func TestParseKeyValues(t *testing.T) {
 			wantErr: false,
 			wantRes: map[string]string{
 				"TEST_INSTANCE_ROLE": "",
-				"TEST_CASE_SEQ":      "0",
 				"TEST_ARTIFACTS":     "/artifacts",
 				"TEST_SIDECAR":       "true",
 			},

--- a/sdk/sync/redis_test.go
+++ b/sdk/sync/redis_test.go
@@ -449,7 +449,6 @@ func randomRunEnv() *runtime.RunEnv {
 		TestSidecar:        false,
 		TestCase:           fmt.Sprintf("testcase-%d", rand.Uint32()),
 		TestRun:            fmt.Sprintf("testrun-%d", rand.Uint32()),
-		TestCaseSeq:        int(rand.Uint32()),
 		TestRepo:           "github.com/ipfs/go-ipfs",
 		TestSubnet:         &runtime.IPNet{IPNet: *subnet},
 		TestCommit:         fmt.Sprintf("%x", sha1.Sum(b)),


### PR DESCRIPTION
Fixes https://github.com/ipfs/testground/issues/466.

* Removes `TEST_CASE_SEQ` as an env variable, including its bindings in the `RunEnv`.
* Test plans now use `TEST_CASE` as a string selector for the test case to run.
* New `runtime.InvokeMap(map[string]runtime.TestCaseFn)` function for supplying a `string => func` map to select the test case from.