### PR TITLE
make: clean docker env, build image, install testground

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@ define eachmod
 	@find . -type f -name go.mod -print0 | xargs -I '{}' -n1 -0 bash -c 'dir="$$(dirname {})" && echo "$${dir}" && cd "$${dir}" && $(1)'
 endef
 
+all: clean docker-ipfs-testground install-testground
+
+clean:
+	docker rm -f testground-sidecar || true
+	docker rm -f testground-redis || true
+	docker rm -f testground-goproxy || true
+
+install-testground:
+	go install ./...
+
 pre-commit:
 	python -m pip install pre-commit --upgrade --user
 	pre-commit install --install-hooks

--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,21 @@ define eachmod
 	@find . -type f -name go.mod -print0 | xargs -I '{}' -n1 -0 bash -c 'dir="$$(dirname {})" && echo "$${dir}" && cd "$${dir}" && $(1)'
 endef
 
-all: clean docker-ipfs-testground install-testground
+all: rm-docker-container-deps build-sidecar-image install
 
-clean:
+rm-docker-container-deps:
 	docker rm -f testground-sidecar || true
 	docker rm -f testground-redis || true
 	docker rm -f testground-goproxy || true
 
-install-testground:
+install:
 	go install ./...
 
 pre-commit:
 	python -m pip install pre-commit --upgrade --user
 	pre-commit install --install-hooks
 
-docker-ipfs-testground:
+build-sidecar-image:
 	docker build -t ipfs/testground .
 
 tidy:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -90,7 +90,7 @@ or
 
 
 ```bash
-make docker-ipfs-testground
+make build-sidecar-image
 ```
 
 ## Running test plans locally with Testground
@@ -113,7 +113,7 @@ smlbench/simple-add-get
 Before you run your first test plan, you need to build a Docker image that provides the "sidecar"
 
 ```
-> make docker-ipfs-testground
+> make build-sidecar-image
 ```
 
 This next command is your first test! It runs the `find-peers` test from the `dht`


### PR DESCRIPTION
An improved Makefile so that we have a simpler way to re-compile and restart Testground locally, and avoid issues like: https://github.com/ipfs/testground/pull/841#issuecomment-613337422