### PR TITLE
add limit range to default namespace

### DIFF
--- a/infra/k8s/install.sh
+++ b/infra/k8s/install.sh
@@ -60,7 +60,7 @@ echo
 echo "Install default container limits"
 echo
 
-kubectl apply -f ./limit-range/limit-range.yaml
+kubectl apply -f ./limit-range/limit-range.yaml --namespace=default
 
 
 echo "Install EFS..."


### PR DESCRIPTION
@coryschwartz I wonder if the way we are adding the LimitRange now, doesn't apply to every namespace in k8s, or just to `default`. I guess we don't want to limit containers in the `kube-system` namespace, but only in the `default` namespace.

Related: https://github.com/ipfs/testground/issues/856