### PR TITLE
increase weave resources ; decrease redis

### DIFF
--- a/infra/k8s/kops-weave/weave.yml
+++ b/infra/k8s/kops-weave/weave.yml
@@ -196,10 +196,14 @@ items:
                   host: 127.0.0.1
                   path: /status
                   port: 6784
+                timeoutSeconds: 5
               resources:
                 requests:
-                  memory: 1024Mi
-                  cpu: 1000m
+                  cpu: 2000m
+                  memory: 2000Mi
+                limits:
+                  cpu: 2000m
+                  memory: 2000Mi
               securityContext:
                 privileged: true
               volumeMounts:

--- a/infra/k8s/testground-infra/values.yaml
+++ b/infra/k8s/testground-infra/values.yaml
@@ -41,8 +41,8 @@ redis:
       cni: flannel
     resources:
       requests:
-        memory: 13000Mi
-        cpu: 6500m
+        memory: 12000Mi
+        cpu: 4000m
       limits:
-        memory: 13000Mi
-        cpu: 6500m
+        memory: 12000Mi
+        cpu: 4000m


### PR DESCRIPTION
I am decreasing resources for Redis, so that both Redis and Weave can fit on a c5.2xlarge.