### PR TITLE
infra: expand network tcp buffers.

### DIFF
--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -115,7 +115,7 @@ spec:
       net.ipv4.tcp_tw_reuse = 1
       net.core.rmem_max = 4194304
       net.core.wmem_max = 4194304
-      net.ipv4.tcp_mem = 262144 524288 1048576
+      net.ipv4.tcp_mem = 262144 524288 1572864
       net.ipv4.tcp_rmem = 16384 131072 4194304
       net.ipv4.tcp_wmem = 16384 131072 4194304
       EOT
@@ -152,11 +152,11 @@ spec:
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 131072
-      net.core.wmem_max = 131072
+      net.core.rmem_max = 4194304
+      net.core.wmem_max = 4194304
       net.ipv4.tcp_mem = 262144 524288 1572864
-      net.ipv4.tcp_rmem = 4096 65536 131072
-      net.ipv4.tcp_wmem = 4096 65536 131072
+      net.ipv4.tcp_rmem = 16384 131072 4194304
+      net.ipv4.tcp_wmem = 16384 131072 4194304
       EOT
   cloudLabels:
     testground.nodetype: plan

--- a/infra/k8s/cluster.yaml
+++ b/infra/k8s/cluster.yaml
@@ -113,11 +113,11 @@ spec:
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 131072
-      net.core.wmem_max = 131072
+      net.core.rmem_max = 4194304
+      net.core.wmem_max = 4194304
       net.ipv4.tcp_mem = 262144 524288 1048576
-      net.ipv4.tcp_rmem = 4096 65536 131072
-      net.ipv4.tcp_wmem = 4096 65536 131072
+      net.ipv4.tcp_rmem = 16384 131072 4194304
+      net.ipv4.tcp_wmem = 16384 131072 4194304
       EOT
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: c5.2xlarge
@@ -154,7 +154,7 @@ spec:
       net.ipv4.tcp_tw_reuse = 1
       net.core.rmem_max = 131072
       net.core.wmem_max = 131072
-      net.ipv4.tcp_mem = 262144 524288 1048576
+      net.ipv4.tcp_mem = 262144 524288 1572864
       net.ipv4.tcp_rmem = 4096 65536 131072
       net.ipv4.tcp_wmem = 4096 65536 131072
       EOT
@@ -194,11 +194,11 @@ spec:
       net.ipv4.ip_local_port_range = 1024 65535
       net.ipv4.tcp_tw_recycle = 1
       net.ipv4.tcp_tw_reuse = 1
-      net.core.rmem_max = 131072
-      net.core.wmem_max = 131072
-      net.ipv4.tcp_mem = 262144 524288 1048576
-      net.ipv4.tcp_rmem = 4096 65536 131072
-      net.ipv4.tcp_wmem = 4096 65536 131072
+      net.core.rmem_max = 4194304
+      net.core.wmem_max = 4194304
+      net.ipv4.tcp_mem = 262144 524288 1572864
+      net.ipv4.tcp_rmem = 16384 131072 4194304
+      net.ipv4.tcp_wmem = 16384 131072 4194304
       EOT
   cloudLabels:
     testground.nodetype: infra


### PR DESCRIPTION
**Calculations:**

* Sizing for ~32768 connections per host. Hosts can run 100 containers. That's 3K conns per container + wiggle room for infrastructure (e.g. weave, prometheus, k8s, etc.)
* 32768 connections, 2 buffers each, 16KiB absolute minimum per buffer (first value of tcp_rmem and tcp_wmem) = 1GiB of global memory = 262144 pages (first pressure value of tcp_mem).
* max. buffer size = 4MiB, applicable separately to receive and send buffers.

---

TODO:

- [ ] Make sure to cherry-pick this change into `testground/infra`. 